### PR TITLE
Own the ingestion pipeline; new Supabase project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,19 @@
 OPENAI_API_KEY=sk-...
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
-SUPABASE_NEWS_FEED_URL=https://your-project.supabase.co/functions/v1/news_entities_feed
-SUPABASE_ARTICLE_LOOKUP_URL=https://your-project.supabase.co/functions/v1/article-content-lookup
-# Optional: falls back to SUPABASE_SERVICE_ROLE_KEY if not set
-# SUPABASE_FUNCTION_AUTH_TOKEN=your-supabase-function-token
+# Extraction cloud functions (Google Cloud Functions)
+# Required to run the ingestion worker (`ingestion-worker`).
+NEWS_EXTRACTION_SUBMIT_URL=https://REGION-PROJECT.cloudfunctions.net/submit-news-extraction-job
+NEWS_EXTRACTION_POLL_URL=https://REGION-PROJECT.cloudfunctions.net/poll-news-extraction-job
+URL_CONTENT_EXTRACTION_SUBMIT_URL=https://REGION-PROJECT.cloudfunctions.net/submit-url-content-extraction-job
+URL_CONTENT_EXTRACTION_POLL_URL=https://REGION-PROJECT.cloudfunctions.net/poll-url-content-extraction-job
+KNOWLEDGE_EXTRACTION_SUBMIT_URL=https://REGION-PROJECT.cloudfunctions.net/submit-article-knowledge-extraction-job
+KNOWLEDGE_EXTRACTION_POLL_URL=https://REGION-PROJECT.cloudfunctions.net/poll-article-knowledge-extraction-job
+EXTRACTION_JOBS_TABLE=extraction_jobs
+EXTRACTION_POLL_INTERVAL_SECONDS=2.0
+EXTRACTION_TIMEOUT_SECONDS=300.0
+INGESTION_MAX_ARTICLES_PER_RUN=200
+
 TOP_N=5
 LOOKBACK_HOURS=6
 OPENAI_MODEL_ARTICLE_DATA_AGENT=gpt-5-nano-2025-08-07

--- a/.github/workflows/editorial-cycle.yml
+++ b/.github/workflows/editorial-cycle.yml
@@ -44,9 +44,6 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          SUPABASE_NEWS_FEED_URL: ${{ secrets.SUPABASE_NEWS_FEED_URL }}
-          SUPABASE_ARTICLE_LOOKUP_URL: ${{ secrets.SUPABASE_ARTICLE_LOOKUP_URL }}
-          SUPABASE_FUNCTION_AUTH_TOKEN: ${{ secrets.SUPABASE_FUNCTION_AUTH_TOKEN }}
 
           # Image cascade (optional — curated pool + headshot + logo work without these)
           IMAGE_SELECTION_URL: ${{ secrets.IMAGE_SELECTION_URL }}

--- a/.github/workflows/ingestion-worker.yml
+++ b/.github/workflows/ingestion-worker.yml
@@ -1,0 +1,64 @@
+name: ingestion-worker
+
+# Populates public.raw_articles / article_entities / article_topics by
+# chaining the three Google Cloud Functions:
+#   news_extraction → url_content_extraction → article_knowledge_extraction
+#
+# The editorial cycle reads from these tables, so this workflow must stay
+# ahead of it. Cadence: every 30 minutes. `since` per run is derived from
+# public.ingestion_watermarks (per-source, 15-min rewind); no lookback-hour
+# env knob.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      max_articles:
+        description: "Cap per run (news_extraction)"
+        required: false
+        default: "200"
+
+concurrency:
+  group: ingestion-worker
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install
+        run: pip install -e .
+
+      - name: Run ingestion
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          NEWS_EXTRACTION_SUBMIT_URL: ${{ secrets.NEWS_EXTRACTION_SUBMIT_URL }}
+          NEWS_EXTRACTION_POLL_URL: ${{ secrets.NEWS_EXTRACTION_POLL_URL }}
+          URL_CONTENT_EXTRACTION_SUBMIT_URL: ${{ secrets.URL_CONTENT_EXTRACTION_SUBMIT_URL }}
+          URL_CONTENT_EXTRACTION_POLL_URL: ${{ secrets.URL_CONTENT_EXTRACTION_POLL_URL }}
+          KNOWLEDGE_EXTRACTION_SUBMIT_URL: ${{ secrets.KNOWLEDGE_EXTRACTION_SUBMIT_URL }}
+          KNOWLEDGE_EXTRACTION_POLL_URL: ${{ secrets.KNOWLEDGE_EXTRACTION_POLL_URL }}
+          EXTRACTION_TIMEOUT_SECONDS: "600"
+          INGESTION_MAX_ARTICLES_PER_RUN: ${{ github.event.inputs.max_articles || '200' }}
+        run: |
+          # Only export model-override env vars when the repo variable is set
+          # and non-empty — otherwise pydantic-settings would coerce "" into
+          # an empty model name. The knowledge CF uses
+          # OPENAI_MODEL_ARTICLE_DATA_AGENT for its LLM call.
+          set -euo pipefail
+          if [ -n "${{ vars.OPENAI_MODEL_ARTICLE_DATA_AGENT }}" ]; then
+            export OPENAI_MODEL_ARTICLE_DATA_AGENT="${{ vars.OPENAI_MODEL_ARTICLE_DATA_AGENT }}"
+          fi
+          ingestion-worker

--- a/app/adapters.py
+++ b/app/adapters.py
@@ -14,9 +14,11 @@ from tenacity import (
 
 from app.schemas import (
     ArticleContentLookupToolResponse,
+    EntityMatch,
     PublishableArticle,
     PublishedStoryRecord,
     RawArticle,
+    StoredArticleRecord,
 )
 
 logger = logging.getLogger(__name__)
@@ -61,17 +63,25 @@ def _check_transient(response: httpx.Response) -> None:
         )
 
 
-# --- Feed reader (edge function) ---
+# --- DB-backed feed reader ---
 
 
-class RawFeedReader:
-    def __init__(self, base_url: str, auth_token: str, timeout_seconds: float = 15.0) -> None:
+class RawArticleDbReader:
+    """Reads articles the ingestion worker has fully processed
+    (status='knowledge_ok') out of public.raw_articles + article_entities,
+    and hydrates them into the existing RawArticle / EntityMatch shape so
+    the editorial workflow downstream is unchanged.
+    """
+
+    def __init__(
+        self, base_url: str, service_role_key: str, timeout_seconds: float = 15.0
+    ) -> None:
         self._client = httpx.AsyncClient(
             base_url=base_url,
             timeout=timeout_seconds,
             headers={
-                "Authorization": f"Bearer {auth_token}",
-                "apikey": auth_token,
+                "Authorization": f"Bearer {service_role_key}",
+                "apikey": service_role_key,
             },
         )
 
@@ -80,33 +90,108 @@ class RawFeedReader:
 
     @_default_retry()
     async def fetch_raw_articles(self, lookback_hours: int) -> list[RawArticle]:
-        logger.info("Fetching news feed", extra={"lookback_hours": lookback_hours})
-        response = await self._client.post("/", json={"lookback_hours": lookback_hours})
+        cutoff = (datetime.now(UTC) - timedelta(hours=lookback_hours)).isoformat()
+        logger.info(
+            "Fetching raw articles from DB",
+            extra={"lookback_hours": lookback_hours, "cutoff": cutoff},
+        )
 
-        _check_transient(response)
-        if response.status_code >= 400:
+        # One round trip for articles + one for their entities. The number of
+        # knowledge_ok rows within a typical 2–6 hour window is small (tens),
+        # so we don't bother with a JOIN or RPC.
+        articles_resp = await self._client.get(
+            "/rest/v1/raw_articles",
+            params={
+                "select": (
+                    "id,url,title,source_name,category,fetched_at,publication_date"
+                ),
+                "status": "eq.knowledge_ok",
+                "fetched_at": f"gte.{cutoff}",
+                "order": "fetched_at.desc",
+            },
+        )
+        _check_transient(articles_resp)
+        if articles_resp.status_code >= 400:
             raise ExternalServiceError(
-                f"News feed request failed with status {response.status_code}: {response.text}"
+                f"raw_articles query failed ({articles_resp.status_code}): "
+                f"{articles_resp.text[:200]}"
             )
 
-        payload = response.json()
-        stories = payload.get("stories", [])
-        result = [RawArticle.model_validate(story) for story in stories]
+        articles = articles_resp.json()
+        if not articles:
+            logger.info("Fetched 0 raw articles")
+            return []
+
+        article_ids = [row["id"] for row in articles]
+        entities_by_article = await self._fetch_entities(article_ids)
+
+        result: list[RawArticle] = []
+        for row in articles:
+            entities = entities_by_article.get(row["id"], [])
+            result.append(
+                RawArticle(
+                    id=row["id"],
+                    url=row["url"],
+                    title=row.get("title") or "",
+                    source_name=row.get("source_name") or "",
+                    category=row.get("category"),
+                    facts_count=len(entities),
+                    entities=entities,
+                )
+            )
         logger.info("Fetched %d raw articles", len(result))
         return result
 
+    async def _fetch_entities(
+        self, article_ids: list[str]
+    ) -> dict[str, list[EntityMatch]]:
+        # PostgREST `in.()` is URL-encoded by httpx; quote strings to handle
+        # commas in ids (uuids are safe but be defensive).
+        quoted = ",".join(f'"{aid}"' for aid in article_ids)
+        response = await self._client.get(
+            "/rest/v1/article_entities",
+            params={
+                "select": "article_id,entity_type,entity_id,matched_name",
+                "article_id": f"in.({quoted})",
+            },
+        )
+        _check_transient(response)
+        if response.status_code >= 400:
+            raise ExternalServiceError(
+                f"article_entities query failed ({response.status_code}): "
+                f"{response.text[:200]}"
+            )
 
-# --- Article content lookup (edge function) ---
+        grouped: dict[str, list[EntityMatch]] = {}
+        for row in response.json():
+            grouped.setdefault(row["article_id"], []).append(
+                EntityMatch(
+                    entity_type=row.get("entity_type") or "",
+                    entity_id=str(row.get("entity_id") or ""),
+                    matched_name=row.get("matched_name") or "",
+                )
+            )
+        return grouped
 
 
-class ArticleLookupAdapter:
-    def __init__(self, base_url: str, auth_token: str, timeout_seconds: float = 15.0) -> None:
+# --- DB-backed article lookup ---
+
+
+class ArticleLookupFromDb:
+    """Serves article content out of public.raw_articles.content instead of
+    a Supabase edge function. Matches the `lookup_article(url)` contract so
+    the article-data agent's tool wiring is unchanged.
+    """
+
+    def __init__(
+        self, base_url: str, service_role_key: str, timeout_seconds: float = 15.0
+    ) -> None:
         self._client = httpx.AsyncClient(
             base_url=base_url,
             timeout=timeout_seconds,
             headers={
-                "Authorization": f"Bearer {auth_token}",
-                "apikey": auth_token,
+                "Authorization": f"Bearer {service_role_key}",
+                "apikey": service_role_key,
             },
         )
 
@@ -115,18 +200,43 @@ class ArticleLookupAdapter:
 
     @_default_retry()
     async def lookup_article(self, url: str) -> ArticleContentLookupToolResponse:
-        logger.debug("Looking up article", extra={"url": url})
-        response = await self._client.post("/", json={"url": url})
-
-        if response.status_code == 404:
-            return ArticleContentLookupToolResponse(requested_url=url, found=False, article=None)
+        logger.debug("Looking up article in DB", extra={"url": url})
+        response = await self._client.get(
+            "/rest/v1/raw_articles",
+            params={
+                "select": "url,title,content",
+                "url": f"eq.{url}",
+                "limit": "1",
+            },
+        )
         _check_transient(response)
         if response.status_code >= 400:
             raise ExternalServiceError(
-                f"Article lookup failed with status {response.status_code}: {response.text}"
+                f"raw_articles lookup failed ({response.status_code}): "
+                f"{response.text[:200]}"
             )
-
-        return ArticleContentLookupToolResponse.model_validate(response.json())
+        rows = response.json()
+        if not rows:
+            return ArticleContentLookupToolResponse(
+                requested_url=url, found=False, article=None
+            )
+        row = rows[0]
+        content = row.get("content") or ""
+        if not content:
+            return ArticleContentLookupToolResponse(
+                requested_url=url, found=False, article=None
+            )
+        return ArticleContentLookupToolResponse(
+            requested_url=url,
+            found=True,
+            article=StoredArticleRecord(
+                url=row.get("url") or url,
+                header=row.get("title"),
+                content=content,
+                description=None,
+                quotes=[],
+            ),
+        )
 
 
 # --- Editorial state (PostgREST direct table access) ---
@@ -215,8 +325,6 @@ class ArticleWriter:
                 "Authorization": f"Bearer {service_role_key}",
                 "apikey": service_role_key,
                 "Content-Type": "application/json",
-                "Content-Profile": "content",
-                "Accept-Profile": "content",
                 "Prefer": "return=representation",
             },
         )
@@ -428,7 +536,7 @@ class ImageUploader:
     ) -> int | None:
         """Insert one row into content.article_images. Returns the new id on success."""
         response = await self._client.post(
-            "/rest/v1/article_images",
+            "/rest/v1/article_images?on_conflict=original_url",
             json={
                 "image_url": image_url,
                 "original_url": original_url,
@@ -437,8 +545,6 @@ class ImageUploader:
             },
             headers={
                 "Content-Type": "application/json",
-                "Content-Profile": "content",
-                "Accept-Profile": "content",
                 # Upsert on unique original_url so reruns don't 409.
                 "Prefer": "return=representation,resolution=merge-duplicates",
             },

--- a/app/adapters.py
+++ b/app/adapters.py
@@ -99,6 +99,11 @@ class RawArticleDbReader:
         # One round trip for articles + one for their entities. The number of
         # knowledge_ok rows within a typical 2–6 hour window is small (tens),
         # so we don't bother with a JOIN or RPC.
+        # Filter on knowledge_extracted_at, not fetched_at: a row's fetched_at
+        # is set at discovery, but editorial can only consume it once it
+        # reaches knowledge_ok. If content/knowledge extraction is slow or
+        # retries, the row's fetched_at can age past the editorial lookback
+        # window before it's ever eligible — silently dropping the story.
         articles_resp = await self._client.get(
             "/rest/v1/raw_articles",
             params={
@@ -106,8 +111,8 @@ class RawArticleDbReader:
                     "id,url,title,source_name,category,fetched_at,publication_date"
                 ),
                 "status": "eq.knowledge_ok",
-                "fetched_at": f"gte.{cutoff}",
-                "order": "fetched_at.desc",
+                "knowledge_extracted_at": f"gte.{cutoff}",
+                "order": "knowledge_extracted_at.desc",
             },
         )
         _check_transient(articles_resp)

--- a/app/clients/__init__.py
+++ b/app/clients/__init__.py
@@ -1,0 +1,37 @@
+"""HTTP clients for the three extraction cloud functions.
+
+Each service exposes a submit/poll async contract. `AsyncJobClient` in
+`base.py` implements the submit → poll loop once; the three concrete
+clients (news, url_content, knowledge) wrap it with typed payloads.
+
+The ingestion worker (app/ingestion/worker.py) orchestrates all three.
+"""
+from app.clients.base import (
+    AsyncJobClient,
+    JobFailedError,
+    JobTimeoutError,
+    SupabaseJobsConfig,
+)
+from app.clients.knowledge_extraction import (
+    KnowledgeExtractionClient,
+    KnowledgeResult,
+    ResolvedEntity,
+    Topic,
+)
+from app.clients.news_extraction import NewsExtractionClient, NewsItem
+from app.clients.url_content import ContentResult, UrlContentClient
+
+__all__ = [
+    "AsyncJobClient",
+    "ContentResult",
+    "JobFailedError",
+    "JobTimeoutError",
+    "KnowledgeExtractionClient",
+    "KnowledgeResult",
+    "NewsExtractionClient",
+    "NewsItem",
+    "ResolvedEntity",
+    "SupabaseJobsConfig",
+    "Topic",
+    "UrlContentClient",
+]

--- a/app/clients/base.py
+++ b/app/clients/base.py
@@ -1,0 +1,138 @@
+"""Shared submit→poll machinery for the three extraction cloud functions.
+
+All three services (news_extraction_service, url_content_extraction_service,
+article_knowledge_extraction) share the same job lifecycle:
+
+  POST {submit_url}  body: {...payload, supabase: {url, key, jobs_table}}
+    → 202 {status: "queued", job_id, expires_at}
+
+  POST {poll_url}    body: {job_id, supabase: {...}}
+    → 200 {status: "queued"|"running", job_id}
+    → 200 {status: "succeeded", job_id, result: {...}}  (atomic consume)
+    → 200 {status: "failed",    job_id, error:  {...}}
+
+`AsyncJobClient.run(payload)` submits, polls at the configured interval,
+raises `JobFailedError` / `JobTimeoutError` on terminal failure, and
+returns the `result` dict on success.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class JobFailedError(RuntimeError):
+    """The remote cloud function reported a terminal failure."""
+
+    def __init__(self, message: str, *, error: dict | None = None) -> None:
+        super().__init__(message)
+        self.error = error or {}
+
+
+class JobTimeoutError(RuntimeError):
+    """Polling exceeded the configured timeout without reaching terminal state."""
+
+
+@dataclass(frozen=True)
+class SupabaseJobsConfig:
+    """Supabase coordinates the cloud functions use to read/write jobs state.
+
+    Every submit and poll body carries this block so the function can talk
+    to our `public.extraction_jobs` table.
+    """
+
+    url: str
+    key: str
+    jobs_table: str = "extraction_jobs"
+
+    def as_dict(self) -> dict[str, str]:
+        return {"url": self.url, "key": self.key, "jobs_table": self.jobs_table}
+
+
+class AsyncJobClient:
+    """Generic submit/poll client for a cloud-function service pair."""
+
+    def __init__(
+        self,
+        *,
+        submit_url: str,
+        poll_url: str,
+        supabase: SupabaseJobsConfig,
+        poll_interval_seconds: float = 2.0,
+        timeout_seconds: float = 300.0,
+        http_timeout_seconds: float = 30.0,
+    ) -> None:
+        self._submit_url = submit_url
+        self._poll_url = poll_url
+        self._supabase = supabase
+        self._poll_interval = poll_interval_seconds
+        self._timeout = timeout_seconds
+        self._client = httpx.AsyncClient(timeout=http_timeout_seconds)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "AsyncJobClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def submit(self, payload: dict[str, Any]) -> str:
+        body = {**payload, "supabase": self._supabase.as_dict()}
+        response = await self._client.post(self._submit_url, json=body)
+        if response.status_code >= 400:
+            raise JobFailedError(
+                f"Submit failed ({response.status_code}): {response.text[:300]}"
+            )
+        data = response.json()
+        job_id = data.get("job_id")
+        if not job_id:
+            raise JobFailedError(f"Submit response missing job_id: {data}")
+        logger.debug("Submitted job %s to %s", job_id, self._submit_url)
+        return job_id
+
+    async def poll_once(self, job_id: str) -> dict[str, Any]:
+        body = {"job_id": job_id, "supabase": self._supabase.as_dict()}
+        response = await self._client.post(self._poll_url, json=body)
+        if response.status_code == 404:
+            raise JobFailedError(f"Job {job_id} not found or already consumed")
+        if response.status_code >= 400:
+            raise JobFailedError(
+                f"Poll failed ({response.status_code}): {response.text[:300]}"
+            )
+        return response.json()
+
+    async def run(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Submit, poll until terminal, and return the `result` dict."""
+        job_id = await self.submit(payload)
+        deadline = asyncio.get_event_loop().time() + self._timeout
+        while True:
+            data = await self.poll_once(job_id)
+            status = data.get("status")
+            if status == "succeeded":
+                result = data.get("result")
+                if result is None:
+                    raise JobFailedError(f"Job {job_id} succeeded with no result")
+                return result
+            if status == "failed":
+                raise JobFailedError(
+                    f"Job {job_id} failed: {data.get('error')}",
+                    error=data.get("error"),
+                )
+            if status == "expired":
+                raise JobFailedError(f"Job {job_id} expired before completion")
+            if status not in ("queued", "running"):
+                raise JobFailedError(f"Job {job_id} returned unknown status {status!r}")
+            if asyncio.get_event_loop().time() >= deadline:
+                raise JobTimeoutError(
+                    f"Job {job_id} did not finish within {self._timeout}s"
+                )
+            await asyncio.sleep(self._poll_interval)

--- a/app/clients/knowledge_extraction.py
+++ b/app/clients/knowledge_extraction.py
@@ -1,0 +1,159 @@
+"""Client for the article_knowledge_extraction cloud function.
+
+Given article text, returns resolved entities (players, teams, coaches)
+and ranked topics. Used to replace the legacy feed's pre-extracted
+`entities[]` field.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.clients.base import AsyncJobClient, SupabaseJobsConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedEntity:
+    entity_type: str
+    entity_id: str
+    mention_text: str | None
+    matched_name: str | None
+    confidence: float | None
+    team_abbr: str | None
+    position: str | None
+
+    @classmethod
+    def from_payload(cls, item: dict[str, Any]) -> "ResolvedEntity":
+        return cls(
+            entity_type=item.get("entity_type", ""),
+            entity_id=str(item.get("entity_id", "")),
+            mention_text=item.get("mention_text"),
+            matched_name=item.get("matched_name"),
+            confidence=_coerce_float(item.get("confidence")),
+            team_abbr=item.get("team_abbr"),
+            position=item.get("position"),
+        )
+
+
+@dataclass(frozen=True)
+class Topic:
+    topic: str
+    confidence: float | None
+    rank: int | None
+
+    @classmethod
+    def from_payload(cls, item: dict[str, Any]) -> "Topic":
+        return cls(
+            topic=item.get("topic", ""),
+            confidence=_coerce_float(item.get("confidence")),
+            rank=_coerce_int(item.get("rank")),
+        )
+
+
+@dataclass(frozen=True)
+class KnowledgeResult:
+    topics: list[Topic] = field(default_factory=list)
+    entities: list[ResolvedEntity] = field(default_factory=list)
+    unresolved_entities: list[dict[str, Any]] = field(default_factory=list)
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "KnowledgeResult":
+        return cls(
+            topics=[Topic.from_payload(t) for t in payload.get("topics", [])],
+            entities=[
+                ResolvedEntity.from_payload(e) for e in payload.get("entities", [])
+            ],
+            unresolved_entities=list(payload.get("unresolved_entities", []) or []),
+        )
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class KnowledgeExtractionClient:
+    """Extracts topics + resolved entities from one article at a time."""
+
+    def __init__(
+        self,
+        *,
+        submit_url: str,
+        poll_url: str,
+        supabase: SupabaseJobsConfig,
+        openai_api_key: str,
+        openai_model: str = "gpt-5.4-mini",
+        poll_interval_seconds: float = 2.0,
+        timeout_seconds: float = 300.0,
+    ) -> None:
+        self._job = AsyncJobClient(
+            submit_url=submit_url,
+            poll_url=poll_url,
+            supabase=supabase,
+            poll_interval_seconds=poll_interval_seconds,
+            timeout_seconds=timeout_seconds,
+        )
+        self._openai_api_key = openai_api_key
+        self._openai_model = openai_model
+
+    async def close(self) -> None:
+        await self._job.close()
+
+    async def extract(
+        self,
+        *,
+        article_id: str,
+        text: str,
+        title: str | None = None,
+        url: str | None = None,
+        max_topics: int = 5,
+        max_entities: int = 15,
+        resolve_entities: bool = True,
+        confidence_threshold: float = 0.6,
+    ) -> KnowledgeResult:
+        payload: dict[str, Any] = {
+            "article": {
+                "article_id": article_id,
+                "text": text,
+                "title": title,
+                "url": url,
+            },
+            "options": {
+                "max_topics": max_topics,
+                "max_entities": max_entities,
+                "resolve_entities": resolve_entities,
+                "confidence_threshold": confidence_threshold,
+            },
+            "llm": {
+                "provider": "openai",
+                "model": self._openai_model,
+                "api_key": self._openai_api_key,
+            },
+        }
+        result = await self._job.run(payload)
+        parsed = KnowledgeResult.from_payload(result)
+        logger.info(
+            "knowledge_extraction: article_id=%s topics=%d entities=%d unresolved=%d",
+            article_id,
+            len(parsed.topics),
+            len(parsed.entities),
+            len(parsed.unresolved_entities),
+        )
+        return parsed

--- a/app/clients/news_extraction.py
+++ b/app/clients/news_extraction.py
@@ -1,0 +1,96 @@
+"""Client for the news_extraction_service cloud function."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from app.clients.base import AsyncJobClient, SupabaseJobsConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class NewsItem:
+    url: str
+    title: str | None
+    description: str | None
+    publication_date: datetime | None
+    source_name: str | None
+    publisher: str | None
+
+    @classmethod
+    def from_payload(cls, item: dict[str, Any]) -> "NewsItem":
+        raw_date = item.get("publication_date")
+        pub_dt: datetime | None = None
+        if isinstance(raw_date, str) and raw_date:
+            try:
+                pub_dt = datetime.fromisoformat(raw_date.replace("Z", "+00:00"))
+            except ValueError:
+                pub_dt = None
+        elif isinstance(raw_date, datetime):
+            pub_dt = raw_date
+        return cls(
+            url=item["url"],
+            title=item.get("title"),
+            description=item.get("description"),
+            publication_date=pub_dt,
+            source_name=item.get("source_name"),
+            publisher=item.get("publisher"),
+        )
+
+
+class NewsExtractionClient:
+    """Wraps submit+poll to discover recent article URLs from configured feeds."""
+
+    def __init__(
+        self,
+        *,
+        submit_url: str,
+        poll_url: str,
+        supabase: SupabaseJobsConfig,
+        poll_interval_seconds: float = 2.0,
+        timeout_seconds: float = 300.0,
+    ) -> None:
+        self._job = AsyncJobClient(
+            submit_url=submit_url,
+            poll_url=poll_url,
+            supabase=supabase,
+            poll_interval_seconds=poll_interval_seconds,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def close(self) -> None:
+        await self._job.close()
+
+    async def extract(
+        self,
+        *,
+        since: datetime | None = None,
+        source_filter: str | None = None,
+        max_articles: int | None = None,
+        max_workers: int | None = None,
+    ) -> list[NewsItem]:
+        """Run the pipeline once and return discovered NewsItems."""
+        options: dict[str, Any] = {}
+        if since is not None:
+            options["since"] = since.isoformat()
+        if source_filter is not None:
+            options["source_filter"] = source_filter
+        if max_articles is not None:
+            options["max_articles"] = max_articles
+        if max_workers is not None:
+            options["max_workers"] = max_workers
+
+        result = await self._job.run({"options": options})
+        items = result.get("items", [])
+        logger.info(
+            "news_extraction returned %d items "
+            "(sources_processed=%s items_filtered=%s)",
+            len(items),
+            result.get("sources_processed"),
+            result.get("items_filtered"),
+        )
+        return [NewsItem.from_payload(it) for it in items]

--- a/app/clients/url_content.py
+++ b/app/clients/url_content.py
@@ -1,0 +1,102 @@
+"""Client for the url_content_extraction_service cloud function."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from app.clients.base import AsyncJobClient, SupabaseJobsConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ContentResult:
+    url: str
+    title: str | None
+    content: str | None  # extracted main text / markdown
+    paragraphs: list[str]
+    error: str | None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None and bool(self.content)
+
+    @classmethod
+    def from_payload(cls, item: dict[str, Any]) -> "ContentResult":
+        paragraphs = item.get("paragraphs") or []
+        content = item.get("content")
+        if content is None and paragraphs:
+            content = "\n\n".join(str(p) for p in paragraphs)
+        return cls(
+            url=item.get("url", ""),
+            title=item.get("title"),
+            content=content,
+            paragraphs=[str(p) for p in paragraphs],
+            error=item.get("error"),
+        )
+
+
+class UrlContentClient:
+    """Extracts main article content from a batch of URLs."""
+
+    def __init__(
+        self,
+        *,
+        submit_url: str,
+        poll_url: str,
+        supabase: SupabaseJobsConfig,
+        poll_interval_seconds: float = 2.0,
+        timeout_seconds: float = 300.0,
+    ) -> None:
+        self._job = AsyncJobClient(
+            submit_url=submit_url,
+            poll_url=poll_url,
+            supabase=supabase,
+            poll_interval_seconds=poll_interval_seconds,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def close(self) -> None:
+        await self._job.close()
+
+    async def extract(
+        self,
+        urls: list[str],
+        *,
+        timeout_seconds: int | None = None,
+        force_playwright: bool | None = None,
+        prefer_lightweight: bool | None = None,
+        max_paragraphs: int | None = None,
+        min_paragraph_chars: int | None = None,
+    ) -> dict[str, ContentResult]:
+        if not urls:
+            return {}
+        options: dict[str, Any] = {}
+        if timeout_seconds is not None:
+            options["timeout_seconds"] = timeout_seconds
+        if force_playwright is not None:
+            options["force_playwright"] = force_playwright
+        if prefer_lightweight is not None:
+            options["prefer_lightweight"] = prefer_lightweight
+        if max_paragraphs is not None:
+            options["max_paragraphs"] = max_paragraphs
+        if min_paragraph_chars is not None:
+            options["min_paragraph_chars"] = min_paragraph_chars
+
+        result = await self._job.run({"urls": urls, "options": options})
+        # CF returns {"articles": [...]} in request order. The CF may rewrite
+        # the url to its resolved form (e.g. AMP redirect), so we key by the
+        # requested url rather than trusting article["url"].
+        items = result.get("articles") or result.get("items") or result.get("results") or []
+        by_url: dict[str, ContentResult] = {}
+        for requested_url, item in zip(urls, items):
+            payload = {**item, "url": requested_url}
+            by_url[requested_url] = ContentResult.from_payload(payload)
+        logger.info(
+            "url_content_extraction returned %d/%d results",
+            len(by_url),
+            len(urls),
+        )
+        return by_url

--- a/app/config.py
+++ b/app/config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-from pydantic import AnyHttpUrl, SecretStr, model_validator
+from pydantic import AnyHttpUrl, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -16,9 +16,21 @@ class Settings(BaseSettings):
     openai_api_key: SecretStr
     supabase_url: AnyHttpUrl
     supabase_service_role_key: SecretStr
-    supabase_news_feed_url: AnyHttpUrl
-    supabase_article_lookup_url: AnyHttpUrl
-    supabase_function_auth_token: SecretStr | None = None
+
+    # Extraction cloud functions (Google Cloud Functions from
+    # tackle_4_loss_intelligence). Each service deploys submit + poll as
+    # separate HTTP functions, so we configure both URLs per service.
+    # Required to run the ingestion worker.
+    news_extraction_submit_url: AnyHttpUrl | None = None
+    news_extraction_poll_url: AnyHttpUrl | None = None
+    url_content_extraction_submit_url: AnyHttpUrl | None = None
+    url_content_extraction_poll_url: AnyHttpUrl | None = None
+    knowledge_extraction_submit_url: AnyHttpUrl | None = None
+    knowledge_extraction_poll_url: AnyHttpUrl | None = None
+    extraction_jobs_table: str = "extraction_jobs"
+    extraction_poll_interval_seconds: float = 2.0
+    extraction_timeout_seconds: float = 300.0
+    ingestion_max_articles_per_run: int = 200
 
     top_n: int = 5
     lookback_hours: int = 2
@@ -41,18 +53,6 @@ class Settings(BaseSettings):
     gemini_image_model: str = "gemini-3.1-flash-image-preview"
     openai_model_vision_validator: str = "gpt-5.4-mini"
     image_selection_timeout_seconds: float = 30.0
-
-    @model_validator(mode="after")
-    def validate_supabase_urls(self) -> "Settings":
-        if str(self.supabase_article_lookup_url) == str(self.supabase_news_feed_url):
-            raise ValueError("SUPABASE_ARTICLE_LOOKUP_URL must differ from SUPABASE_NEWS_FEED_URL")
-        return self
-
-    def resolved_function_auth_token(self) -> str:
-        """Return the edge-function auth token, falling back to the service role key."""
-        if self.supabase_function_auth_token is not None:
-            return self.supabase_function_auth_token.get_secret_value()
-        return self.supabase_service_role_key.get_secret_value()
 
     def agent_models(self) -> dict[str, str]:
         return {

--- a/app/editorial/tools.py
+++ b/app/editorial/tools.py
@@ -8,7 +8,7 @@ from agents import Agent, Runner, function_tool
 from agents.tool import FunctionTool
 from agents.tool_context import ToolContext
 
-from app.adapters import ArticleLookupAdapter
+from app.adapters import ArticleLookupFromDb
 from app.editorial.helpers import coerce_output, recompute_cluster_fingerprint
 from app.schemas import (
     ArticleContentLookupToolResponse,
@@ -42,7 +42,7 @@ async def _run_nested_agent(
     return output.model_dump(mode="json")
 
 
-def build_article_lookup_tool(adapter: ArticleLookupAdapter) -> FunctionTool:
+def build_article_lookup_tool(adapter: ArticleLookupFromDb) -> FunctionTool:
     @function_tool(
         name_override="lookup_article_content",
         description_override=(

--- a/app/editorial/workflow.py
+++ b/app/editorial/workflow.py
@@ -6,7 +6,7 @@ import os
 
 from agents import Runner
 
-from app.adapters import ArticleLookupAdapter, EditorialStateStore, RawFeedReader
+from app.adapters import ArticleLookupFromDb, EditorialStateStore, RawArticleDbReader
 from app.config import Settings
 from app.editorial.agents import (
     build_article_data_agent,
@@ -39,8 +39,8 @@ class EditorialWorkflow:
         self,
         *,
         settings: Settings,
-        news_feed: RawFeedReader,
-        article_lookup: ArticleLookupAdapter,
+        news_feed: RawArticleDbReader,
+        article_lookup: ArticleLookupFromDb,
         state_store: EditorialStateStore,
     ) -> None:
         self._news_feed = news_feed

--- a/app/ingestion/__init__.py
+++ b/app/ingestion/__init__.py
@@ -1,0 +1,7 @@
+"""Ingestion pipeline.
+
+Populates `public.raw_articles` + `public.article_entities` +
+`public.article_topics` by chaining the three extraction cloud functions.
+The editorial cycle reads from these tables; ingestion runs on its own
+cron so the two phases are fully decoupled.
+"""

--- a/app/ingestion/cli.py
+++ b/app/ingestion/cli.py
@@ -1,0 +1,30 @@
+"""CLI entry point for the ingestion worker.
+
+Registered in pyproject.toml as `ingestion-worker`. Intended to be run on
+a cron (every 15-30 minutes) independently from the editorial cycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+
+from app.config import get_settings
+from app.ingestion.worker import run_ingestion_cycle
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    settings = get_settings()
+    summary = asyncio.run(run_ingestion_cycle(settings))
+    print(json.dumps(summary.as_dict()))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/app/ingestion/store.py
+++ b/app/ingestion/store.py
@@ -1,0 +1,294 @@
+"""PostgREST-backed store for the ingestion pipeline.
+
+Owns all reads and writes against `public.raw_articles`,
+`public.article_entities`, and `public.article_topics`.
+
+Status machine on `raw_articles`:
+
+  discovered   — row inserted from news_extraction output
+  content_ok   — url_content_extraction filled `content`
+  knowledge_ok — article_knowledge_extraction filled entities + topics
+  failed       — terminal; see `error` jsonb for details
+
+The ingestion worker is idempotent: re-running it picks up rows at
+whichever status they stopped at (insert dedups on `url`, state updates
+are set-based).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from app.clients import ContentResult, KnowledgeResult, NewsItem
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PendingArticle:
+    id: str
+    url: str
+    title: str | None
+    content: str | None
+
+
+class RawArticleStore:
+    """Minimal PostgREST wrapper for raw_articles + article_entities/topics."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        service_role_key: str,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        self._client = httpx.AsyncClient(
+            base_url=base_url.rstrip("/"),
+            timeout=timeout_seconds,
+            headers={
+                "Authorization": f"Bearer {service_role_key}",
+                "apikey": service_role_key,
+                "Content-Type": "application/json",
+            },
+        )
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    # ---------------------------------------------------------------- reads
+
+    async def list_known_urls(self, since: datetime) -> set[str]:
+        """Return URLs already present in raw_articles with fetched_at >= `since`."""
+        cutoff = since.astimezone(UTC).isoformat()
+        response = await self._client.get(
+            "/rest/v1/raw_articles",
+            params={"select": "url", "fetched_at": f"gte.{cutoff}"},
+        )
+        response.raise_for_status()
+        return {row["url"] for row in response.json() if row.get("url")}
+
+    async def list_pending(
+        self, *, status: str, limit: int = 100
+    ) -> list[PendingArticle]:
+        """Return rows at a given stage waiting for the next transition."""
+        response = await self._client.get(
+            "/rest/v1/raw_articles",
+            params={
+                "select": "id,url,title,content",
+                "status": f"eq.{status}",
+                "order": "fetched_at.desc",
+                "limit": str(limit),
+            },
+        )
+        response.raise_for_status()
+        return [
+            PendingArticle(
+                id=row["id"],
+                url=row["url"],
+                title=row.get("title"),
+                content=row.get("content"),
+            )
+            for row in response.json()
+        ]
+
+    # ---------------------------------------------------------------- writes
+
+    async def insert_discovered(self, items: list[NewsItem]) -> int:
+        """Bulk-insert discovered URLs. Duplicates on unique(url) are ignored.
+
+        Returns the number of rows actually inserted (i.e. not already known).
+        """
+        if not items:
+            return 0
+        rows = []
+        for it in items:
+            rows.append(
+                {
+                    "url": it.url,
+                    "title": it.title,
+                    "source_name": it.source_name,
+                    "publisher": it.publisher,
+                    "publication_date": (
+                        it.publication_date.astimezone(UTC).isoformat()
+                        if it.publication_date
+                        else None
+                    ),
+                    "status": "discovered",
+                }
+            )
+        # PostgREST `resolution=ignore-duplicates` only applies to the primary
+        # key by default. We dedup on url (a secondary unique constraint), so
+        # route the upsert through `on_conflict=url`.
+        response = await self._client.post(
+            "/rest/v1/raw_articles?on_conflict=url",
+            json=rows,
+            headers={
+                "Prefer": "resolution=ignore-duplicates,return=representation",
+            },
+        )
+        if response.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"insert_discovered failed: {response.text[:300]}",
+                request=response.request,
+                response=response,
+            )
+        inserted = response.json()
+        logger.info("Inserted %d new raw_articles (out of %d)", len(inserted), len(rows))
+        return len(inserted)
+
+    async def update_content(
+        self, article_id: str, result: ContentResult
+    ) -> None:
+        payload = {
+            "content": result.content,
+            "content_extracted_at": _now_iso(),
+            "status": "content_ok",
+        }
+        if result.title and not result.error:
+            payload["title"] = result.title
+        await self._patch(article_id, payload)
+
+    async def update_knowledge(
+        self, article_id: str, result: KnowledgeResult
+    ) -> None:
+        """Write entities + topics, flip status to knowledge_ok."""
+        if result.entities:
+            entity_rows = [
+                {
+                    "article_id": article_id,
+                    "entity_type": e.entity_type,
+                    "entity_id": e.entity_id,
+                    "mention_text": e.mention_text,
+                    "matched_name": e.matched_name,
+                    "confidence": e.confidence,
+                    "team_abbr": e.team_abbr,
+                    "position": e.position,
+                }
+                for e in result.entities
+                if e.entity_type and e.entity_id
+            ]
+            if entity_rows:
+                response = await self._client.post(
+                    "/rest/v1/article_entities",
+                    json=entity_rows,
+                    headers={
+                        "Prefer": "resolution=merge-duplicates,return=minimal",
+                    },
+                )
+                if response.status_code >= 400:
+                    raise httpx.HTTPStatusError(
+                        f"article_entities insert failed: {response.text[:300]}",
+                        request=response.request,
+                        response=response,
+                    )
+
+        if result.topics:
+            topic_rows = [
+                {
+                    "article_id": article_id,
+                    "topic": t.topic,
+                    "confidence": t.confidence,
+                    "rank": t.rank,
+                }
+                for t in result.topics
+                if t.topic
+            ]
+            if topic_rows:
+                response = await self._client.post(
+                    "/rest/v1/article_topics",
+                    json=topic_rows,
+                    headers={
+                        "Prefer": "resolution=merge-duplicates,return=minimal",
+                    },
+                )
+                if response.status_code >= 400:
+                    raise httpx.HTTPStatusError(
+                        f"article_topics insert failed: {response.text[:300]}",
+                        request=response.request,
+                        response=response,
+                    )
+
+        await self._patch(
+            article_id,
+            {
+                "knowledge_extracted_at": _now_iso(),
+                "status": "knowledge_ok",
+            },
+        )
+
+    async def mark_failed(self, article_id: str, error: dict[str, Any]) -> None:
+        await self._patch(
+            article_id,
+            {"status": "failed", "error": error},
+        )
+
+    # --------------------------------------------------------- watermarks
+
+    async def read_watermarks(self) -> dict[str, datetime]:
+        """Return {source_name: last_publication_at} for every known source."""
+        response = await self._client.get(
+            "/rest/v1/ingestion_watermarks",
+            params={"select": "source_name,last_publication_at"},
+        )
+        response.raise_for_status()
+        out: dict[str, datetime] = {}
+        for row in response.json():
+            raw = row.get("last_publication_at")
+            if not raw:
+                continue
+            out[row["source_name"]] = datetime.fromisoformat(
+                raw.replace("Z", "+00:00")
+            )
+        return out
+
+    async def upsert_watermarks(self, watermarks: dict[str, datetime]) -> None:
+        """Bulk upsert per-source watermarks. `watermarks` is the new value
+        for each source; this method writes only rows that would move the
+        watermark forward (callers are expected to have already computed
+        max() against any prior value)."""
+        if not watermarks:
+            return
+        rows = [
+            {
+                "source_name": src,
+                "last_publication_at": ts.astimezone(UTC).isoformat(),
+                "updated_at": _now_iso(),
+            }
+            for src, ts in watermarks.items()
+        ]
+        response = await self._client.post(
+            "/rest/v1/ingestion_watermarks?on_conflict=source_name",
+            json=rows,
+            headers={"Prefer": "resolution=merge-duplicates,return=minimal"},
+        )
+        if response.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"ingestion_watermarks upsert failed: {response.text[:300]}",
+                request=response.request,
+                response=response,
+            )
+
+    # ---------------------------------------------------------------- helpers
+
+    async def _patch(self, article_id: str, payload: dict[str, Any]) -> None:
+        body = {**payload, "updated_at": _now_iso()}
+        response = await self._client.patch(
+            f"/rest/v1/raw_articles?id=eq.{article_id}",
+            json=body,
+            headers={"Prefer": "return=minimal"},
+        )
+        if response.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"raw_articles patch {article_id} failed: {response.text[:300]}",
+                request=response.request,
+                response=response,
+            )
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()

--- a/app/ingestion/store.py
+++ b/app/ingestion/store.py
@@ -75,13 +75,18 @@ class RawArticleStore:
     async def list_pending(
         self, *, status: str, limit: int = 100
     ) -> list[PendingArticle]:
-        """Return rows at a given stage waiting for the next transition."""
+        """Return rows at a given stage waiting for the next transition.
+
+        FIFO by fetched_at — each run processes a bounded batch, so
+        descending order would starve older pending rows if the ingestion
+        rate ever exceeds the batch size. Always drain the oldest first.
+        """
         response = await self._client.get(
             "/rest/v1/raw_articles",
             params={
                 "select": "id,url,title,content",
                 "status": f"eq.{status}",
-                "order": "fetched_at.desc",
+                "order": "fetched_at.asc",
                 "limit": str(limit),
             },
         )

--- a/app/ingestion/worker.py
+++ b/app/ingestion/worker.py
@@ -1,0 +1,270 @@
+"""Ingestion worker. Chains the three extraction cloud functions.
+
+One call to `run_ingestion_cycle(settings)` performs the full pipeline:
+
+  1. Discover: news_extraction → insert new rows into raw_articles.
+  2. Content:  url_content_extraction → fill content for 'discovered' rows.
+  3. Knowledge: article_knowledge_extraction → fill entities/topics for
+     'content_ok' rows.
+
+Each stage operates on the current DB state, so the worker is idempotent
+and crash-safe: reruns pick up wherever the previous run left off.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from app.clients import (
+    JobFailedError,
+    JobTimeoutError,
+    KnowledgeExtractionClient,
+    NewsExtractionClient,
+    SupabaseJobsConfig,
+    UrlContentClient,
+)
+from app.config import Settings
+from app.ingestion.store import PendingArticle, RawArticleStore
+
+logger = logging.getLogger(__name__)
+
+_CONTENT_BATCH_SIZE = 10
+
+
+@dataclass
+class IngestionSummary:
+    discovered: int = 0
+    content_updated: int = 0
+    content_failed: int = 0
+    knowledge_updated: int = 0
+    knowledge_failed: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "discovered": self.discovered,
+            "content_updated": self.content_updated,
+            "content_failed": self.content_failed,
+            "knowledge_updated": self.knowledge_updated,
+            "knowledge_failed": self.knowledge_failed,
+        }
+
+
+async def run_ingestion_cycle(settings: Settings) -> IngestionSummary:
+    """Run one end-to-end ingestion cycle. Returns counts for logging."""
+    _require_extraction_config(settings)
+
+    supabase_jobs = SupabaseJobsConfig(
+        url=str(settings.supabase_url).rstrip("/"),
+        key=settings.supabase_service_role_key.get_secret_value(),
+        jobs_table=settings.extraction_jobs_table,
+    )
+
+    store = RawArticleStore(
+        base_url=str(settings.supabase_url),
+        service_role_key=settings.supabase_service_role_key.get_secret_value(),
+    )
+    news_client = NewsExtractionClient(
+        submit_url=str(settings.news_extraction_submit_url),
+        poll_url=str(settings.news_extraction_poll_url),
+        supabase=supabase_jobs,
+        poll_interval_seconds=settings.extraction_poll_interval_seconds,
+        timeout_seconds=settings.extraction_timeout_seconds,
+    )
+    content_client = UrlContentClient(
+        submit_url=str(settings.url_content_extraction_submit_url),
+        poll_url=str(settings.url_content_extraction_poll_url),
+        supabase=supabase_jobs,
+        poll_interval_seconds=settings.extraction_poll_interval_seconds,
+        timeout_seconds=settings.extraction_timeout_seconds,
+    )
+    knowledge_client = KnowledgeExtractionClient(
+        submit_url=str(settings.knowledge_extraction_submit_url),
+        poll_url=str(settings.knowledge_extraction_poll_url),
+        supabase=supabase_jobs,
+        openai_api_key=settings.openai_api_key.get_secret_value(),
+        openai_model=settings.openai_model_article_data_agent,
+        poll_interval_seconds=settings.extraction_poll_interval_seconds,
+        timeout_seconds=settings.extraction_timeout_seconds,
+    )
+
+    summary = IngestionSummary()
+    try:
+        summary.discovered = await _discover(
+            settings=settings, store=store, news_client=news_client
+        )
+        summary.content_updated, summary.content_failed = await _extract_content(
+            store=store, content_client=content_client
+        )
+        summary.knowledge_updated, summary.knowledge_failed = await _extract_knowledge(
+            store=store, knowledge_client=knowledge_client
+        )
+    finally:
+        await store.close()
+        await news_client.close()
+        await content_client.close()
+        await knowledge_client.close()
+
+    logger.info("Ingestion cycle summary: %s", summary.as_dict())
+    return summary
+
+
+# --------------------------------------------------------------------- stages
+
+
+_FIRST_RUN_LOOKBACK = timedelta(hours=6)
+_WATERMARK_REWIND = timedelta(minutes=15)
+
+
+async def _discover(
+    *,
+    settings: Settings,
+    store: RawArticleStore,
+    news_client: NewsExtractionClient,
+) -> int:
+    """Pull new articles via news_extraction and advance watermarks.
+
+    Watermarks advance AT DISCOVERY (not after content/knowledge succeed):
+    a dead link or a flaky LLM shouldn't block the next ingestion window
+    for its source. Failed rows remain visible in raw_articles.status for
+    debugging.
+    """
+    watermarks = await store.read_watermarks()
+    if watermarks:
+        since = min(watermarks.values()) - _WATERMARK_REWIND
+    else:
+        since = datetime.now(UTC) - _FIRST_RUN_LOOKBACK
+
+    items = await news_client.extract(
+        since=since,
+        max_articles=settings.ingestion_max_articles_per_run,
+    )
+    if not items:
+        return 0
+
+    # Advance per-source watermark from the full response (including
+    # already-known URLs) — otherwise a source whose latest article is
+    # already in our DB would never advance, and we'd keep re-fetching
+    # the same window forever.
+    new_marks: dict[str, datetime] = {}
+    for item in items:
+        if not item.source_name or item.publication_date is None:
+            continue
+        prev = new_marks.get(item.source_name)
+        if prev is None or item.publication_date > prev:
+            new_marks[item.source_name] = item.publication_date
+
+    # Only write a source's mark if it would move forward compared to the
+    # value we read at the start of the run.
+    forward: dict[str, datetime] = {
+        src: ts
+        for src, ts in new_marks.items()
+        if watermarks.get(src) is None or ts > watermarks[src]
+    }
+
+    inserted = await store.insert_discovered(items)
+    if forward:
+        await store.upsert_watermarks(forward)
+    return inserted
+
+
+async def _extract_content(
+    *,
+    store: RawArticleStore,
+    content_client: UrlContentClient,
+) -> tuple[int, int]:
+    pending: list[PendingArticle] = await store.list_pending(
+        status="discovered", limit=_CONTENT_BATCH_SIZE
+    )
+    if not pending:
+        return 0, 0
+
+    urls = [p.url for p in pending]
+    try:
+        results = await content_client.extract(urls)
+    except (JobFailedError, JobTimeoutError) as exc:
+        logger.error("url_content batch failed: %s", exc)
+        for p in pending:
+            await store.mark_failed(p.id, {"stage": "content", "error": str(exc)})
+        return 0, len(pending)
+
+    ok, failed = 0, 0
+    for p in pending:
+        result = results.get(p.url)
+        if result is None:
+            await store.mark_failed(
+                p.id, {"stage": "content", "error": "missing from batch response"}
+            )
+            failed += 1
+            continue
+        if not result.ok:
+            await store.mark_failed(
+                p.id,
+                {"stage": "content", "error": result.error or "empty content"},
+            )
+            failed += 1
+            continue
+        await store.update_content(p.id, result)
+        ok += 1
+    return ok, failed
+
+
+async def _extract_knowledge(
+    *,
+    store: RawArticleStore,
+    knowledge_client: KnowledgeExtractionClient,
+) -> tuple[int, int]:
+    pending: list[PendingArticle] = await store.list_pending(
+        status="content_ok", limit=_CONTENT_BATCH_SIZE
+    )
+    if not pending:
+        return 0, 0
+
+    ok, failed = 0, 0
+    for p in pending:
+        if not p.content:
+            await store.mark_failed(
+                p.id, {"stage": "knowledge", "error": "content_ok row has no content"}
+            )
+            failed += 1
+            continue
+        try:
+            result = await knowledge_client.extract(
+                article_id=p.id,
+                text=p.content,
+                title=p.title,
+                url=p.url,
+            )
+        except (JobFailedError, JobTimeoutError) as exc:
+            logger.warning("knowledge extraction failed for %s: %s", p.id, exc)
+            await store.mark_failed(
+                p.id, {"stage": "knowledge", "error": str(exc)}
+            )
+            failed += 1
+            continue
+        await store.update_knowledge(p.id, result)
+        ok += 1
+    return ok, failed
+
+
+# --------------------------------------------------------------------- config
+
+
+def _require_extraction_config(settings: Settings) -> None:
+    missing = [
+        name
+        for name, value in {
+            "NEWS_EXTRACTION_SUBMIT_URL": settings.news_extraction_submit_url,
+            "NEWS_EXTRACTION_POLL_URL": settings.news_extraction_poll_url,
+            "URL_CONTENT_EXTRACTION_SUBMIT_URL": settings.url_content_extraction_submit_url,
+            "URL_CONTENT_EXTRACTION_POLL_URL": settings.url_content_extraction_poll_url,
+            "KNOWLEDGE_EXTRACTION_SUBMIT_URL": settings.knowledge_extraction_submit_url,
+            "KNOWLEDGE_EXTRACTION_POLL_URL": settings.knowledge_extraction_poll_url,
+        }.items()
+        if value is None
+    ]
+    if missing:
+        raise RuntimeError(
+            "Ingestion worker requires these env vars: " + ", ".join(missing)
+        )

--- a/app/orchestration.py
+++ b/app/orchestration.py
@@ -5,12 +5,12 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 from app.adapters import (
-    ArticleLookupAdapter,
+    ArticleLookupFromDb,
     ArticleWriter,
     EditorialStateStore,
     ExternalServiceError,
     ImageUploader,
-    RawFeedReader,
+    RawArticleDbReader,
 )
 from app.config import Settings, get_settings
 from app.editorial.context import CycleRunContext
@@ -140,14 +140,14 @@ class CycleOrchestrator:
 
 
 def build_default_orchestrator(settings: Settings) -> CycleOrchestrator:
-    news_feed = RawFeedReader(
-        base_url=str(settings.supabase_news_feed_url),
-        auth_token=settings.resolved_function_auth_token(),
+    news_feed = RawArticleDbReader(
+        base_url=str(settings.supabase_url),
+        service_role_key=settings.supabase_service_role_key.get_secret_value(),
         timeout_seconds=settings.news_timeout_seconds,
     )
-    article_lookup = ArticleLookupAdapter(
-        base_url=str(settings.supabase_article_lookup_url),
-        auth_token=settings.resolved_function_auth_token(),
+    article_lookup = ArticleLookupFromDb(
+        base_url=str(settings.supabase_url),
+        service_role_key=settings.supabase_service_role_key.get_secret_value(),
         timeout_seconds=settings.news_timeout_seconds,
     )
     state_store = EditorialStateStore(

--- a/app/writer/image_selector.py
+++ b/app/writer/image_selector.py
@@ -597,7 +597,6 @@ class ImageSelector:
             resp = await self._http.get(
                 f"{self._supabase_base}/rest/v1/curated_images",
                 params=params,
-                headers={"Accept-Profile": "content"},
             )
         except Exception as exc:
             logger.warning("curated lookup error (%s/%s): %s", team_code, scene, exc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
 
 [project.scripts]
 editorial-cycle = "app.cli:app"
+ingestion-worker = "app.ingestion.cli:main"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/scripts/migrate_curated_images.py
+++ b/scripts/migrate_curated_images.py
@@ -1,0 +1,162 @@
+"""One-off: copy curated_images rows + storage objects from the legacy
+Supabase project into the new one.
+
+Reads `content.curated_images` from the legacy project, downloads each image
+from its public storage URL, uploads it to the new project's `images`
+bucket at the same path, and inserts a row into `public.curated_images`
+with a rewritten image_url.
+
+Idempotent — uses `x-upsert: true` on storage, and
+`Prefer: resolution=merge-duplicates` + `on_conflict=slug` on the row
+insert.
+
+Usage:
+  ./venv/bin/python scripts/migrate_curated_images.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from urllib.parse import urlparse
+
+import httpx
+
+
+LEGACY_URL = "https://yqtiuzhedkfacwgormhn.supabase.co"
+LEGACY_KEY = os.environ.get("LEGACY_SUPABASE_KEY", "")
+
+NEW_URL = "https://aiknjzinyxzhoseyxqev.supabase.co"
+NEW_KEY = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+NEW_BUCKET = "images"
+
+BATCH = 50
+
+
+async def fetch_legacy_rows(client: httpx.AsyncClient) -> list[dict]:
+    headers = {
+        "apikey": LEGACY_KEY,
+        "Authorization": f"Bearer {LEGACY_KEY}",
+        "Accept-Profile": "content",
+    }
+    response = await client.get(
+        f"{LEGACY_URL}/rest/v1/curated_images",
+        headers=headers,
+        params={"select": "*", "order": "id.asc"},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+async def copy_one(
+    client: httpx.AsyncClient, row: dict
+) -> tuple[str, str | None]:
+    """Download one image from legacy, upload to new. Returns (slug, err)."""
+    legacy_url = row["image_url"]
+    try:
+        resp = await client.get(legacy_url)
+        resp.raise_for_status()
+        content = resp.content
+    except Exception as exc:
+        return row["slug"], f"download failed: {exc}"
+
+    path = urlparse(legacy_url).path
+    # path looks like /storage/v1/object/public/images/curated/ARI_sideline.png
+    # We need the object key after the bucket: curated/ARI_sideline.png
+    try:
+        key = path.split(f"/public/{NEW_BUCKET}/", 1)[1]
+    except IndexError:
+        return row["slug"], f"cannot parse bucket path: {path}"
+
+    upload_url = f"{NEW_URL}/storage/v1/object/{NEW_BUCKET}/{key}"
+    try:
+        up = await client.post(
+            upload_url,
+            content=content,
+            headers={
+                "apikey": NEW_KEY,
+                "Authorization": f"Bearer {NEW_KEY}",
+                "Content-Type": resp.headers.get("content-type", "image/png"),
+                "x-upsert": "true",
+            },
+        )
+        if up.status_code >= 400:
+            return row["slug"], f"upload failed ({up.status_code}): {up.text[:200]}"
+    except Exception as exc:
+        return row["slug"], f"upload crashed: {exc}"
+
+    return row["slug"], None
+
+
+async def insert_rows(client: httpx.AsyncClient, rows: list[dict]) -> None:
+    """Bulk-insert all rows into the new project in one round-trip."""
+    payload = []
+    for row in rows:
+        legacy_path = urlparse(row["image_url"]).path
+        key = legacy_path.split(f"/public/{NEW_BUCKET}/", 1)[1]
+        new_url = f"{NEW_URL}/storage/v1/object/public/{NEW_BUCKET}/{key}"
+        payload.append({
+            "slug": row["slug"],
+            "team_code": row.get("team_code"),
+            "scene": row["scene"],
+            "description": row.get("description") or row["slug"],
+            "image_url": new_url,
+            "generated_by": row.get("generated_by") or "gemini",
+            "prompt": row.get("prompt"),
+            "active": row.get("active", True),
+        })
+
+    response = await client.post(
+        f"{NEW_URL}/rest/v1/curated_images?on_conflict=slug",
+        headers={
+            "apikey": NEW_KEY,
+            "Authorization": f"Bearer {NEW_KEY}",
+            "Content-Type": "application/json",
+            "Prefer": "resolution=merge-duplicates,return=minimal",
+        },
+        json=payload,
+    )
+    if response.status_code >= 400:
+        raise RuntimeError(
+            f"insert failed ({response.status_code}): {response.text[:500]}"
+        )
+    print(f"Inserted/upserted {len(payload)} rows")
+
+
+async def main() -> int:
+    if not LEGACY_KEY:
+        print("Set LEGACY_SUPABASE_KEY in the env before running.")
+        return 2
+
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        rows = await fetch_legacy_rows(client)
+        print(f"Fetched {len(rows)} curated_images rows from legacy")
+
+        errors: list[tuple[str, str]] = []
+        ok = 0
+        for i in range(0, len(rows), BATCH):
+            batch = rows[i : i + BATCH]
+            results = await asyncio.gather(
+                *(copy_one(client, r) for r in batch)
+            )
+            for slug, err in results:
+                if err:
+                    errors.append((slug, err))
+                else:
+                    ok += 1
+            print(f"Batch {i // BATCH + 1}: {ok}/{len(rows)} uploaded")
+
+        if errors:
+            print(f"\n{len(errors)} upload errors:")
+            for slug, err in errors[:10]:
+                print(f"  {slug}: {err}")
+
+        successful_slugs = {r["slug"] for r in rows} - {s for s, _ in errors}
+        successful_rows = [r for r in rows if r["slug"] in successful_slugs]
+        await insert_rows(client, successful_rows)
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/supabase/migrations/v2/001_extraction_jobs.sql
+++ b/supabase/migrations/v2/001_extraction_jobs.sql
@@ -1,0 +1,49 @@
+-- Async job state for the three Google Cloud Functions:
+--   news_extraction_service, url_content_extraction_service,
+--   article_knowledge_extraction
+--
+-- Each function writes one row per submitted job, a background worker
+-- updates it, and the client polls. Terminal polls atomically delete
+-- via consume_extraction_job(uuid). A 5-min cleanup job re-queues
+-- stale rows and expires abandoned ones.
+--
+-- Shared table, distinguished by `service` tag.
+
+CREATE TABLE IF NOT EXISTS public.extraction_jobs (
+    id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    service        text NOT NULL,        -- 'news_extraction' | 'url_content_extraction' | 'article_knowledge_extraction'
+    status         text NOT NULL DEFAULT 'queued',  -- queued | running | succeeded | failed | expired
+    payload        jsonb NOT NULL,
+    result         jsonb,
+    error          jsonb,
+    worker_token   text,
+    started_at     timestamptz,
+    expires_at     timestamptz NOT NULL,
+    created_at     timestamptz NOT NULL DEFAULT now(),
+    updated_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS extraction_jobs_status_idx
+    ON public.extraction_jobs (service, status, created_at);
+CREATE INDEX IF NOT EXISTS extraction_jobs_expires_idx
+    ON public.extraction_jobs (expires_at);
+
+-- Atomic consume: return the row and delete it in one statement.
+-- Used by the cloud functions' terminal-poll code path.
+CREATE OR REPLACE FUNCTION public.consume_extraction_job(job_id uuid)
+RETURNS SETOF public.extraction_jobs
+LANGUAGE sql
+AS $$
+    DELETE FROM public.extraction_jobs
+    WHERE id = job_id
+      AND status IN ('succeeded', 'failed', 'expired')
+    RETURNING *;
+$$;
+
+ALTER TABLE public.extraction_jobs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access"
+    ON public.extraction_jobs
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');

--- a/supabase/migrations/v2/002_reference_data.sql
+++ b/supabase/migrations/v2/002_reference_data.sql
@@ -1,0 +1,20 @@
+-- Reference data (players, teams, games, player_weekly_stats, …) is managed
+-- by the `data_loading` cloud function from the tackle_4_loss_intelligence
+-- repo. Its CLI scripts (scripts/players_cli.py, scripts/games_cli.py, …)
+-- create and populate these tables in public schema using nflreadpy as the
+-- source.
+--
+-- We do NOT recreate those DDLs here — the loader owns them and they must
+-- match its transformer output. Run the loader once against this project
+-- before the first editorial cycle:
+--
+--   SUPABASE_URL=... SUPABASE_KEY=... python scripts/players_cli.py
+--   SUPABASE_URL=... SUPABASE_KEY=... python scripts/games_cli.py --season 2026
+--
+-- The editorial cycle's image selector reads `public.players.headshot` and
+-- `public.players.display_name` (see app/writer/image_selector.py tier 2).
+-- Downstream consumers may also read `public.teams` and `public.games`.
+--
+-- This file exists as a placeholder so the migration history reflects the
+-- dependency.
+SELECT 1;

--- a/supabase/migrations/v2/003_raw_articles.sql
+++ b/supabase/migrations/v2/003_raw_articles.sql
@@ -1,0 +1,43 @@
+-- Owned ingestion store. Replaces the legacy news-feed edge function.
+--
+-- Populated by app/ingestion/worker.py, which chains:
+--   1. news_extraction_service → inserts rows with status='discovered'
+--   2. url_content_extraction_service → fills content, status='content_ok'
+--   3. article_knowledge_extraction → fills article_entities + article_topics,
+--      status='knowledge_ok'
+--
+-- editorial/workflow.py reads rows with status='knowledge_ok' within the
+-- lookback window and hydrates RawArticle objects (see app/schemas.py).
+
+CREATE TABLE IF NOT EXISTS public.raw_articles (
+    id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    url                     text NOT NULL UNIQUE,
+    title                   text,
+    source_name             text,
+    publisher               text,
+    category                text,
+    publication_date        timestamptz,
+    fetched_at              timestamptz NOT NULL DEFAULT now(),
+    content                 text,
+    content_extracted_at    timestamptz,
+    knowledge_extracted_at  timestamptz,
+    status                  text NOT NULL DEFAULT 'discovered',
+                                -- discovered | content_ok | knowledge_ok | failed
+    error                   jsonb,
+    updated_at              timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT raw_articles_status_check
+        CHECK (status IN ('discovered','content_ok','knowledge_ok','failed'))
+);
+
+CREATE INDEX IF NOT EXISTS raw_articles_status_idx
+    ON public.raw_articles (status, fetched_at DESC);
+CREATE INDEX IF NOT EXISTS raw_articles_pub_date_idx
+    ON public.raw_articles (publication_date DESC);
+
+ALTER TABLE public.raw_articles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access"
+    ON public.raw_articles
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');

--- a/supabase/migrations/v2/004_article_entities.sql
+++ b/supabase/migrations/v2/004_article_entities.sql
@@ -1,0 +1,34 @@
+-- Resolved entity mentions per article. Replaces the embedded `entities[]`
+-- that the legacy feed returned inline. Filled by the knowledge-extraction
+-- step of the ingestion worker.
+--
+-- entity_id conventions (matched to shape legacy code expects):
+--   entity_type='player' → GSIS id, e.g. '00-0026158'
+--   entity_type='team'   → 3-letter team code, e.g. 'KC'
+--   entity_type='game'   → nflverse game_id, e.g. '2024_01_KC_BAL'
+--   entity_type='coach'  → stable coach slug
+
+CREATE TABLE IF NOT EXISTS public.article_entities (
+    article_id    uuid NOT NULL
+                  REFERENCES public.raw_articles(id) ON DELETE CASCADE,
+    entity_type   text NOT NULL,
+    entity_id     text NOT NULL,
+    mention_text  text,
+    matched_name  text,
+    confidence    real,
+    team_abbr     text,
+    position      text,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (article_id, entity_type, entity_id)
+);
+
+CREATE INDEX IF NOT EXISTS article_entities_by_entity_idx
+    ON public.article_entities (entity_type, entity_id);
+
+ALTER TABLE public.article_entities ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access"
+    ON public.article_entities
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');

--- a/supabase/migrations/v2/005_article_topics.sql
+++ b/supabase/migrations/v2/005_article_topics.sql
@@ -1,0 +1,26 @@
+-- Topics extracted per article by the knowledge-extraction step.
+-- Stored separately from article_entities so downstream queries can
+-- filter/rank by topic independently. Not yet consumed by the editorial
+-- cycle, but populated from day one so we can layer topic-based ranking
+-- later without a backfill.
+
+CREATE TABLE IF NOT EXISTS public.article_topics (
+    article_id  uuid NOT NULL
+                REFERENCES public.raw_articles(id) ON DELETE CASCADE,
+    topic       text NOT NULL,
+    confidence  real,
+    rank        int,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (article_id, topic)
+);
+
+CREATE INDEX IF NOT EXISTS article_topics_by_topic_idx
+    ON public.article_topics (topic);
+
+ALTER TABLE public.article_topics ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access"
+    ON public.article_topics
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');

--- a/supabase/migrations/v2/006_editorial_state.sql
+++ b/supabase/migrations/v2/006_editorial_state.sql
@@ -1,0 +1,28 @@
+-- Cross-cycle dedup memory: one row per published story (by fingerprint).
+-- Consolidates legacy migrations 001–002 from supabase/migrations/ into a
+-- single table definition for the fresh v2 project.
+
+CREATE TABLE IF NOT EXISTS public.editorial_state (
+    id                   bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    story_fingerprint    text NOT NULL,
+    published_at         timestamptz NOT NULL DEFAULT now(),
+    last_updated_at      timestamptz NOT NULL DEFAULT now(),
+    supabase_article_id  bigint NOT NULL,
+    cycle_id             text NOT NULL,
+    cluster_headline     text NOT NULL DEFAULT '',
+    source_urls          text[] NOT NULL DEFAULT '{}',
+    CONSTRAINT uq_editorial_state_fingerprint UNIQUE (story_fingerprint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_editorial_state_published_at
+    ON public.editorial_state (published_at);
+CREATE INDEX IF NOT EXISTS idx_editorial_state_cycle_id
+    ON public.editorial_state (cycle_id);
+
+ALTER TABLE public.editorial_state ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access"
+    ON public.editorial_state
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');

--- a/supabase/migrations/v2/007_team_article.sql
+++ b/supabase/migrations/v2/007_team_article.sql
@@ -1,0 +1,55 @@
+-- Published article output. Consolidates legacy migrations 003–007 so the
+-- v2 project has the final column set from day one.
+--
+-- Written by app/writer via PostgREST (public schema — no profile header).
+-- Uniqueness: (story_fingerprint, language) is the natural upsert key for
+-- the multi-language write path (en-US + de-DE per story).
+
+-- NOTE: The foreign key on `team` references the reference-data table
+-- `public.teams` which is created by the data_loading cloud function
+-- (see 002_reference_data.sql). If you apply this migration before
+-- running the loader, leave the FK commented out and add it later.
+-- We define the column as text (nullable) so bad values can be retried
+-- with team=NULL — see ArticleWriter.write_article.
+
+CREATE TABLE IF NOT EXISTS public.team_article (
+    id                 bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    team               text,
+    language           text NOT NULL DEFAULT 'en-US',
+    headline           text NOT NULL,
+    sub_headline       text,
+    introduction       text,
+    content            text NOT NULL,
+    x_post             text,
+    bullet_points      text,
+    image              text,
+    tts_file           text,
+    author             text,
+    mentioned_players  text[] NOT NULL DEFAULT '{}',
+    sources            jsonb NOT NULL DEFAULT '[]'::jsonb,
+    story_fingerprint  text,
+    created_at         timestamptz NOT NULL DEFAULT now(),
+    updated_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS team_article_fingerprint_language_idx
+    ON public.team_article (story_fingerprint, language)
+    WHERE story_fingerprint IS NOT NULL;
+CREATE INDEX IF NOT EXISTS team_article_team_idx
+    ON public.team_article (team);
+CREATE INDEX IF NOT EXISTS team_article_language_idx
+    ON public.team_article (language);
+
+-- Optional FK to public.teams(team_code). Uncomment after loader runs.
+-- ALTER TABLE public.team_article
+--     ADD CONSTRAINT team_article_team_fkey
+--     FOREIGN KEY (team) REFERENCES public.teams(team_code)
+--     ON DELETE SET NULL;
+
+ALTER TABLE public.team_article ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access"
+    ON public.team_article
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');

--- a/supabase/migrations/v2/008_curated_images.sql
+++ b/supabase/migrations/v2/008_curated_images.sql
@@ -1,0 +1,36 @@
+-- Curated image pool, tier 3 of the image_selector cascade.
+-- Copied verbatim from legacy migration 005_curated_images.sql.
+--
+-- Pre-generated + human-reviewed PNGs uploaded via
+-- scripts/upload_curated_pool.py (in the legacy repo). Re-upload the pool
+-- into the new project's storage bucket and reinsert the rows.
+
+CREATE TABLE IF NOT EXISTS public.curated_images (
+    id           bigserial PRIMARY KEY,
+    slug         text NOT NULL UNIQUE,
+    team_code    text,                      -- null for generic scenes
+    scene        text NOT NULL,
+    description  text NOT NULL,
+    image_url    text NOT NULL,
+    generated_by text NOT NULL DEFAULT 'gemini',
+    prompt       text,
+    active       boolean NOT NULL DEFAULT true,
+    created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS curated_images_team_scene_idx
+    ON public.curated_images (team_code, scene)
+    WHERE active;
+
+CREATE INDEX IF NOT EXISTS curated_images_scene_idx
+    ON public.curated_images (scene)
+    WHERE active AND team_code IS NULL;
+
+ALTER TABLE public.curated_images ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access"
+    ON public.curated_images
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+

--- a/supabase/migrations/v2/009_article_images.sql
+++ b/supabase/migrations/v2/009_article_images.sql
@@ -1,0 +1,27 @@
+-- Provenance store for images used on published articles. Written by
+-- app/adapters.py::ImageUploader.record_metadata when an image is sourced
+-- from the web (Google CC / Wikimedia) or uploaded fresh.
+--
+-- Keyed on original_url so reruns on the same story do not duplicate rows
+-- (merge-duplicates upsert in the uploader).
+
+CREATE TABLE IF NOT EXISTS public.article_images (
+    id           bigserial PRIMARY KEY,
+    image_url    text NOT NULL,
+    original_url text NOT NULL UNIQUE,
+    source       text NOT NULL,        -- 'google_cc' | 'wikimedia' | 'player_headshot' | 'curated' | ...
+    author       text NOT NULL DEFAULT '',
+    created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS article_images_source_idx
+    ON public.article_images (source);
+
+ALTER TABLE public.article_images ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access"
+    ON public.article_images
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+

--- a/supabase/migrations/v2/010_ingestion_watermarks.sql
+++ b/supabase/migrations/v2/010_ingestion_watermarks.sql
@@ -1,0 +1,27 @@
+-- Per-source watermark for news_extraction. Keyed on source_name (the
+-- feed label the CF emits, e.g. "ESPN", "CBSSports"). Advanced on every
+-- ingestion run from the max publication_date seen for each source in
+-- the CF response, BEFORE content/knowledge extraction runs — so later
+-- stage failures never block future ingestion.
+--
+-- Replaces the old `INGESTION_NEWS_LOOKBACK_HOURS` env knob.
+--
+-- Read path: app/ingestion/worker._discover()
+--   since = (min(last_publication_at) if any else now()-6h) - 15min
+-- The 15-min rewind buffer absorbs any back-dated articles the feed may
+-- publish slightly out of order; URL dedup absorbs the duplicates that
+-- produces.
+
+CREATE TABLE IF NOT EXISTS public.ingestion_watermarks (
+    source_name          text PRIMARY KEY,
+    last_publication_at  timestamptz NOT NULL,
+    updated_at           timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.ingestion_watermarks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access"
+    ON public.ingestion_watermarks
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');

--- a/supabase/migrations/v2/011_raw_articles_knowledge_extracted_at_idx.sql
+++ b/supabase/migrations/v2/011_raw_articles_knowledge_extracted_at_idx.sql
@@ -1,0 +1,14 @@
+-- Index for the editorial cycle's feed query:
+--   SELECT … FROM raw_articles
+--   WHERE status = 'knowledge_ok'
+--     AND knowledge_extracted_at >= now() - interval 'N hours'
+--   ORDER BY knowledge_extracted_at DESC;
+--
+-- We filter on knowledge_extracted_at (not fetched_at) so rows that took a
+-- while to traverse the ingestion pipeline don't age out of the editorial
+-- window before they're ever eligible. See app/adapters.py
+-- RawArticleDbReader.fetch_raw_articles.
+
+CREATE INDEX IF NOT EXISTS raw_articles_knowledge_extracted_at_idx
+    ON public.raw_articles (knowledge_extracted_at DESC)
+    WHERE status = 'knowledge_ok';

--- a/supabase/migrations/v2/README.md
+++ b/supabase/migrations/v2/README.md
@@ -1,0 +1,44 @@
+# v2 Migrations — Clean Supabase Project
+
+These migrations define the full schema for the new, standalone Supabase
+project that replaces the legacy setup. Apply in order against an empty
+project (SQL Editor; `supabase db push` is not used).
+
+## Apply order
+
+1. `001_extraction_jobs.sql` — shared job queue for the three GCF services.
+2. `002_reference_data.sql` — **no DDL**; placeholder that documents the
+   dependency on the `data_loading` cloud function. Run its CLI scripts
+   **after** this migration to create and fill `public.players`,
+   `public.teams`, `public.games`, etc.
+3. `003_raw_articles.sql` — owned ingestion store (URL → content).
+4. `004_article_entities.sql` — resolved entity mentions per article.
+5. `005_article_topics.sql` — topics per article.
+6. `006_editorial_state.sql` — cross-cycle dedup memory.
+7. `007_team_article.sql` — published article output.
+8. `008_curated_images.sql` — tier-3 image pool.
+9. `009_article_images.sql` — image provenance.
+
+All tables live in `public`. No PostgREST schema exposure toggle needed.
+
+## Reference data loader
+
+Run once (and thereafter on a cadence) against this project:
+
+```bash
+cd tackle_4_loss_intelligence/src/functions/data_loading
+SUPABASE_URL=... SUPABASE_KEY=... python scripts/players_cli.py
+SUPABASE_URL=... SUPABASE_KEY=... python scripts/games_cli.py --season 2026
+```
+
+The image selector tier 2 requires `public.players.headshot` and
+`public.players.display_name`.
+
+## Curated image pool
+
+The curated image bucket + rows need to be copied from the legacy project:
+
+1. Create a Storage bucket (default name `images`) in the new project.
+2. Export `content.curated_images` rows from legacy and insert into new.
+3. Mirror the storage objects (see legacy `scripts/upload_curated_pool.py`
+   for upload helpers).

--- a/tests/test_clients_base.py
+++ b/tests/test_clients_base.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import pytest
+import httpx
+
+from app.clients.base import (
+    AsyncJobClient,
+    JobFailedError,
+    JobTimeoutError,
+    SupabaseJobsConfig,
+)
+
+
+def _client_with_transport(transport: httpx.MockTransport, **kwargs) -> AsyncJobClient:
+    c = AsyncJobClient(
+        submit_url="https://svc/submit",
+        poll_url="https://svc/poll",
+        supabase=SupabaseJobsConfig(url="https://db", key="k"),
+        poll_interval_seconds=kwargs.pop("poll_interval_seconds", 0.0),
+        timeout_seconds=kwargs.pop("timeout_seconds", 5.0),
+    )
+    c._client = httpx.AsyncClient(transport=transport)
+    return c
+
+
+class TestAsyncJobClient:
+    async def test_run_happy_path(self) -> None:
+        calls = {"submit": 0, "poll": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = request.read().decode()
+            if request.url.path.endswith("/submit"):
+                calls["submit"] += 1
+                assert '"url":"https://db"' in body
+                assert '"jobs_table":"extraction_jobs"' in body
+                return httpx.Response(202, json={"status": "queued", "job_id": "abc"})
+            calls["poll"] += 1
+            if calls["poll"] == 1:
+                return httpx.Response(200, json={"status": "running", "job_id": "abc"})
+            return httpx.Response(
+                200, json={"status": "succeeded", "job_id": "abc", "result": {"ok": True}}
+            )
+
+        async with _client_with_transport(httpx.MockTransport(handler)) as client:
+            result = await client.run({"options": {"since": "2026-04-23T00:00:00+00:00"}})
+
+        assert result == {"ok": True}
+        assert calls == {"submit": 1, "poll": 2}
+
+    async def test_submit_passes_supabase_block(self) -> None:
+        captured: dict = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/submit"):
+                captured["body"] = request.read()
+                return httpx.Response(202, json={"job_id": "j1"})
+            return httpx.Response(
+                200, json={"status": "succeeded", "job_id": "j1", "result": {}}
+            )
+
+        async with _client_with_transport(httpx.MockTransport(handler)) as client:
+            await client.run({"options": {}})
+
+        import json as _json
+
+        body = _json.loads(captured["body"])
+        assert body["supabase"] == {
+            "url": "https://db",
+            "key": "k",
+            "jobs_table": "extraction_jobs",
+        }
+
+    async def test_run_raises_on_failed_status(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/submit"):
+                return httpx.Response(202, json={"job_id": "j"})
+            return httpx.Response(
+                200,
+                json={
+                    "status": "failed",
+                    "job_id": "j",
+                    "error": {"message": "boom"},
+                },
+            )
+
+        async with _client_with_transport(httpx.MockTransport(handler)) as client:
+            with pytest.raises(JobFailedError) as exc:
+                await client.run({})
+
+        assert exc.value.error == {"message": "boom"}
+
+    async def test_run_raises_on_submit_http_error(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="server err")
+
+        async with _client_with_transport(httpx.MockTransport(handler)) as client:
+            with pytest.raises(JobFailedError, match="Submit failed"):
+                await client.run({})
+
+    async def test_run_raises_on_poll_404_terminal(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/submit"):
+                return httpx.Response(202, json={"job_id": "j"})
+            return httpx.Response(404, text="not found")
+
+        async with _client_with_transport(httpx.MockTransport(handler)) as client:
+            with pytest.raises(JobFailedError, match="not found"):
+                await client.run({})
+
+    async def test_run_raises_on_unknown_status(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/submit"):
+                return httpx.Response(202, json={"job_id": "j"})
+            return httpx.Response(200, json={"status": "mystery", "job_id": "j"})
+
+        async with _client_with_transport(httpx.MockTransport(handler)) as client:
+            with pytest.raises(JobFailedError, match="unknown status"):
+                await client.run({})
+
+    async def test_run_raises_timeout(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/submit"):
+                return httpx.Response(202, json={"job_id": "j"})
+            return httpx.Response(200, json={"status": "running", "job_id": "j"})
+
+        async with _client_with_transport(
+            httpx.MockTransport(handler),
+            poll_interval_seconds=0.0,
+            timeout_seconds=0.01,
+        ) as client:
+            with pytest.raises(JobTimeoutError):
+                await client.run({})

--- a/tests/test_clients_news.py
+++ b/tests/test_clients_news.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json as _json
+from datetime import UTC, datetime
+
+import httpx
+
+from app.clients.base import SupabaseJobsConfig
+from app.clients.news_extraction import NewsExtractionClient, NewsItem
+
+
+def _make_client(handler) -> NewsExtractionClient:
+    client = NewsExtractionClient(
+        submit_url="https://svc/submit",
+        poll_url="https://svc/poll",
+        supabase=SupabaseJobsConfig(url="https://db", key="k"),
+        poll_interval_seconds=0.0,
+        timeout_seconds=5.0,
+    )
+    client._job._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return client
+
+
+class TestNewsExtractionClient:
+    async def test_extract_returns_parsed_items(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/submit"):
+                return httpx.Response(202, json={"job_id": "j"})
+            return httpx.Response(
+                200,
+                json={
+                    "status": "succeeded",
+                    "job_id": "j",
+                    "result": {
+                        "items": [
+                            {
+                                "url": "https://ex.com/a",
+                                "title": "A",
+                                "publication_date": "2026-04-23T10:00:00Z",
+                                "source_name": "ESPN",
+                                "publisher": "ESPN Inc",
+                                "description": "d",
+                            },
+                            {
+                                "url": "https://ex.com/b",
+                                "title": "B",
+                                "publication_date": None,
+                                "source_name": "CBS",
+                            },
+                        ],
+                        "sources_processed": 2,
+                        "items_extracted": 2,
+                        "items_filtered": 0,
+                    },
+                },
+            )
+
+        client = _make_client(handler)
+        items = await client.extract(since=datetime(2026, 4, 23, tzinfo=UTC))
+        await client.close()
+
+        assert len(items) == 2
+        assert items[0].url == "https://ex.com/a"
+        assert items[0].publication_date == datetime(2026, 4, 23, 10, 0, tzinfo=UTC)
+        assert items[1].publication_date is None
+
+    async def test_extract_sends_options_payload(self) -> None:
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/submit"):
+                captured["body"] = _json.loads(request.read())
+                return httpx.Response(202, json={"job_id": "j"})
+            return httpx.Response(
+                200,
+                json={"status": "succeeded", "job_id": "j", "result": {"items": []}},
+            )
+
+        client = _make_client(handler)
+        await client.extract(
+            since=datetime(2026, 4, 23, 10, 0, tzinfo=UTC),
+            source_filter="ESPN",
+            max_articles=50,
+        )
+        await client.close()
+
+        options = captured["body"]["options"]
+        assert options["since"] == "2026-04-23T10:00:00+00:00"
+        assert options["source_filter"] == "ESPN"
+        assert options["max_articles"] == 50
+        assert "max_workers" not in options
+
+
+class TestNewsItem:
+    def test_from_payload_parses_zulu_datetime(self) -> None:
+        item = NewsItem.from_payload(
+            {"url": "u", "publication_date": "2026-04-23T00:00:00Z"}
+        )
+        assert item.publication_date == datetime(2026, 4, 23, tzinfo=UTC)
+
+    def test_from_payload_tolerates_garbage_date(self) -> None:
+        item = NewsItem.from_payload({"url": "u", "publication_date": "not-a-date"})
+        assert item.publication_date is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,9 +9,6 @@ def fake_settings(monkeypatch: pytest.MonkeyPatch) -> Settings:
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
     monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "test-key")
-    monkeypatch.setenv("SUPABASE_NEWS_FEED_URL", "https://test.supabase.co/functions/v1/feed")
-    monkeypatch.setenv("SUPABASE_ARTICLE_LOOKUP_URL", "https://test.supabase.co/functions/v1/lookup")
-    monkeypatch.delenv("SUPABASE_FUNCTION_AUTH_TOKEN", raising=False)
     # Clear any model overrides from real .env
     for key in (
         "OPENAI_MODEL_ARTICLE_DATA_AGENT",
@@ -29,9 +26,12 @@ class TestSettings:
         assert fake_settings.top_n == 5
         assert fake_settings.lookback_hours == 2
 
-    def test_agent_model_returns_correct_model(self, fake_settings: Settings) -> None:
-        assert fake_settings.agent_model("article_data_agent") == "gpt-5-nano-2025-08-07"
-        assert fake_settings.agent_model("editorial_orchestrator_agent") == "gpt-5.2-2025-12-11"
+    def test_agent_model_returns_default(self, fake_settings: Settings) -> None:
+        # Defaults when no env override is set.
+        assert fake_settings.agent_model("article_data_agent") == "gpt-5.4-nano"
+        assert (
+            fake_settings.agent_model("editorial_orchestrator_agent") == "gpt-5.4"
+        )
 
     def test_agent_model_raises_on_unknown(self, fake_settings: Settings) -> None:
         with pytest.raises(ValueError, match="Unknown agent name"):
@@ -46,27 +46,3 @@ class TestSettings:
             "article_writer_agent",
             "persona_selector_agent",
         }
-
-    def test_validates_url_mismatch(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
-        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "test-key")
-        monkeypatch.setenv("SUPABASE_NEWS_FEED_URL", "https://test.supabase.co/functions/v1/same")
-        monkeypatch.setenv("SUPABASE_ARTICLE_LOOKUP_URL", "https://test.supabase.co/functions/v1/same")
-        # SUPABASE_FUNCTION_AUTH_TOKEN intentionally omitted — falls back to service role key
-        with pytest.raises(Exception, match="must differ"):
-            Settings(_env_file=None)
-
-    def test_resolved_function_auth_token_fallback(self, fake_settings: Settings) -> None:
-        assert fake_settings.supabase_function_auth_token is None
-        assert fake_settings.resolved_function_auth_token() == "test-key"
-
-    def test_resolved_function_auth_token_explicit(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
-        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "test-key")
-        monkeypatch.setenv("SUPABASE_NEWS_FEED_URL", "https://test.supabase.co/functions/v1/feed")
-        monkeypatch.setenv("SUPABASE_ARTICLE_LOOKUP_URL", "https://test.supabase.co/functions/v1/lookup")
-        monkeypatch.setenv("SUPABASE_FUNCTION_AUTH_TOKEN", "explicit-token")
-        s = Settings(_env_file=None)
-        assert s.resolved_function_auth_token() == "explicit-token"

--- a/tests/test_db_adapters.py
+++ b/tests/test_db_adapters.py
@@ -89,10 +89,11 @@ class TestRawArticleDbReader:
         assert a2.entities == []
         assert a2.facts_count == 0
 
-        # First call filters on status + cutoff
+        # First call filters on status + cutoff keyed on completion time.
         articles_params = calls[0][1]
         assert articles_params["status"] == "eq.knowledge_ok"
-        assert articles_params["fetched_at"].startswith("gte.")
+        assert articles_params["knowledge_extracted_at"].startswith("gte.")
+        assert articles_params["order"].startswith("knowledge_extracted_at.")
         # Second call scopes to collected article ids
         ent_params = calls[1][1]
         assert "a1" in ent_params["article_id"]

--- a/tests/test_db_adapters.py
+++ b/tests/test_db_adapters.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import httpx
+
+from app.adapters import ArticleLookupFromDb, RawArticleDbReader
+
+
+def _reader_with_handler(handler) -> RawArticleDbReader:
+    reader = RawArticleDbReader(base_url="https://db", service_role_key="k")
+    reader._client = httpx.AsyncClient(
+        base_url="https://db",
+        transport=httpx.MockTransport(handler),
+        headers={"Authorization": "Bearer k", "apikey": "k"},
+    )
+    return reader
+
+
+def _lookup_with_handler(handler) -> ArticleLookupFromDb:
+    a = ArticleLookupFromDb(base_url="https://db", service_role_key="k")
+    a._client = httpx.AsyncClient(
+        base_url="https://db",
+        transport=httpx.MockTransport(handler),
+        headers={"Authorization": "Bearer k", "apikey": "k"},
+    )
+    return a
+
+
+class TestRawArticleDbReader:
+    async def test_fetch_raw_articles_joins_entities(self) -> None:
+        calls: list[tuple[str, dict]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append((request.url.path, dict(request.url.params)))
+            if request.url.path.endswith("/raw_articles"):
+                return httpx.Response(
+                    200,
+                    json=[
+                        {
+                            "id": "a1",
+                            "url": "https://ex.com/a",
+                            "title": "A",
+                            "source_name": "ESPN",
+                            "category": "nfl",
+                            "fetched_at": "2026-04-23T12:00:00+00:00",
+                            "publication_date": "2026-04-23T10:00:00+00:00",
+                        },
+                        {
+                            "id": "a2",
+                            "url": "https://ex.com/b",
+                            "title": "B",
+                            "source_name": "CBS",
+                            "category": None,
+                            "fetched_at": "2026-04-23T11:00:00+00:00",
+                            "publication_date": None,
+                        },
+                    ],
+                )
+            # article_entities
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "article_id": "a1",
+                        "entity_type": "player",
+                        "entity_id": "00-0026158",
+                        "matched_name": "Josh Allen",
+                    },
+                    {
+                        "article_id": "a1",
+                        "entity_type": "team",
+                        "entity_id": "BUF",
+                        "matched_name": "Buffalo Bills",
+                    },
+                ],
+            )
+
+        reader = _reader_with_handler(handler)
+        articles = await reader.fetch_raw_articles(lookback_hours=6)
+        await reader.close()
+
+        assert len(articles) == 2
+        a1 = next(a for a in articles if a.id == "a1")
+        assert a1.url == "https://ex.com/a"
+        assert a1.source_name == "ESPN"
+        assert {e.entity_id for e in a1.entities} == {"00-0026158", "BUF"}
+        assert a1.facts_count == 2
+
+        a2 = next(a for a in articles if a.id == "a2")
+        assert a2.entities == []
+        assert a2.facts_count == 0
+
+        # First call filters on status + cutoff
+        articles_params = calls[0][1]
+        assert articles_params["status"] == "eq.knowledge_ok"
+        assert articles_params["fetched_at"].startswith("gte.")
+        # Second call scopes to collected article ids
+        ent_params = calls[1][1]
+        assert "a1" in ent_params["article_id"]
+        assert "a2" in ent_params["article_id"]
+
+    async def test_fetch_raw_articles_empty_skips_entity_query(self) -> None:
+        calls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request.url.path)
+            return httpx.Response(200, json=[])
+
+        reader = _reader_with_handler(handler)
+        articles = await reader.fetch_raw_articles(lookback_hours=2)
+        await reader.close()
+
+        assert articles == []
+        assert calls == ["/rest/v1/raw_articles"]
+
+
+class TestArticleLookupFromDb:
+    async def test_lookup_found(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path.endswith("/raw_articles")
+            assert dict(request.url.params)["url"] == "eq.https://ex.com/a"
+            return httpx.Response(
+                200,
+                json=[{"url": "https://ex.com/a", "title": "A", "content": "body"}],
+            )
+
+        lookup = _lookup_with_handler(handler)
+        resp = await lookup.lookup_article("https://ex.com/a")
+        await lookup.close()
+
+        assert resp.found is True
+        assert resp.article is not None
+        assert resp.article.content == "body"
+        assert resp.article.header == "A"
+
+    async def test_lookup_not_found_returns_found_false(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[])
+
+        lookup = _lookup_with_handler(handler)
+        resp = await lookup.lookup_article("https://ex.com/missing")
+        await lookup.close()
+
+        assert resp.found is False
+        assert resp.article is None
+
+    async def test_lookup_row_without_content_is_not_found(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, json=[{"url": "https://ex.com/a", "title": "A", "content": None}]
+            )
+
+        lookup = _lookup_with_handler(handler)
+        resp = await lookup.lookup_article("https://ex.com/a")
+        await lookup.close()
+
+        assert resp.found is False
+        assert resp.article is None

--- a/tests/test_ingestion_store.py
+++ b/tests/test_ingestion_store.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json as _json
+from datetime import UTC, datetime
+
+import httpx
+
+from app.clients import ContentResult, KnowledgeResult, NewsItem, ResolvedEntity, Topic
+from app.ingestion.store import RawArticleStore
+
+
+def _store_with_handler(handler) -> RawArticleStore:
+    store = RawArticleStore(base_url="https://db", service_role_key="k")
+    store._client = httpx.AsyncClient(
+        base_url="https://db",
+        transport=httpx.MockTransport(handler),
+        headers={"Authorization": "Bearer k", "apikey": "k"},
+    )
+    return store
+
+
+class TestRawArticleStore:
+    async def test_insert_discovered_posts_with_ignore_duplicates(self) -> None:
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["prefer"] = request.headers.get("prefer")
+            captured["body"] = _json.loads(request.read())
+            # postgrest returns only newly inserted rows when ignore-duplicates
+            return httpx.Response(
+                201,
+                json=[{"id": "1", "url": "https://ex.com/a"}],
+            )
+
+        store = _store_with_handler(handler)
+        inserted = await store.insert_discovered(
+            [
+                NewsItem(
+                    url="https://ex.com/a",
+                    title="A",
+                    description=None,
+                    publication_date=datetime(2026, 4, 23, tzinfo=UTC),
+                    source_name="ESPN",
+                    publisher=None,
+                ),
+                NewsItem(
+                    url="https://ex.com/b",
+                    title=None,
+                    description=None,
+                    publication_date=None,
+                    source_name=None,
+                    publisher=None,
+                ),
+            ]
+        )
+        await store.close()
+
+        assert inserted == 1
+        assert "ignore-duplicates" in captured["prefer"]
+        assert len(captured["body"]) == 2
+        assert captured["body"][0]["status"] == "discovered"
+        assert captured["body"][0]["publication_date"] == "2026-04-23T00:00:00+00:00"
+        assert captured["body"][1]["publication_date"] is None
+
+    async def test_insert_discovered_no_items_skips_http(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover
+            raise AssertionError("should not be called")
+
+        store = _store_with_handler(handler)
+        n = await store.insert_discovered([])
+        await store.close()
+        assert n == 0
+
+    async def test_list_known_urls_filters_by_since(self) -> None:
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["params"] = dict(request.url.params)
+            return httpx.Response(
+                200,
+                json=[{"url": "https://ex.com/a"}, {"url": "https://ex.com/b"}],
+            )
+
+        store = _store_with_handler(handler)
+        urls = await store.list_known_urls(datetime(2026, 4, 23, tzinfo=UTC))
+        await store.close()
+
+        assert urls == {"https://ex.com/a", "https://ex.com/b"}
+        assert captured["params"]["fetched_at"].startswith("gte.2026-04-23")
+
+    async def test_update_content_patches_fields(self) -> None:
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["method"] = request.method
+            captured["params"] = dict(request.url.params)
+            captured["body"] = _json.loads(request.read())
+            return httpx.Response(204)
+
+        store = _store_with_handler(handler)
+        await store.update_content(
+            "article-1",
+            ContentResult(
+                url="u",
+                title="Updated Title",
+                content="body",
+                paragraphs=["body"],
+                error=None,
+            ),
+        )
+        await store.close()
+
+        assert captured["method"] == "PATCH"
+        assert captured["params"]["id"] == "eq.article-1"
+        assert captured["body"]["status"] == "content_ok"
+        assert captured["body"]["content"] == "body"
+        assert captured["body"]["title"] == "Updated Title"
+
+    async def test_update_knowledge_writes_entities_topics_and_patches(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append((request.method, request.url.path))
+            return httpx.Response(204 if request.method == "PATCH" else 201, json=[])
+
+        store = _store_with_handler(handler)
+        await store.update_knowledge(
+            "article-1",
+            KnowledgeResult(
+                topics=[Topic(topic="trade", confidence=0.9, rank=1)],
+                entities=[
+                    ResolvedEntity(
+                        entity_type="player",
+                        entity_id="00-0026158",
+                        mention_text="Josh Allen",
+                        matched_name="Josh Allen",
+                        confidence=0.98,
+                        team_abbr="BUF",
+                        position="QB",
+                    )
+                ],
+                unresolved_entities=[],
+            ),
+        )
+        await store.close()
+
+        paths = [path for _, path in calls]
+        methods = [m for m, _ in calls]
+        assert any("article_entities" in p for p in paths)
+        assert any("article_topics" in p for p in paths)
+        assert methods.count("PATCH") == 1
+
+    async def test_update_knowledge_skips_empty_buckets(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append((request.method, request.url.path))
+            return httpx.Response(204)
+
+        store = _store_with_handler(handler)
+        await store.update_knowledge("a1", KnowledgeResult())
+        await store.close()
+
+        # Only the PATCH to raw_articles — no entity/topic posts.
+        assert len(calls) == 1
+        assert calls[0][0] == "PATCH"

--- a/tests/test_ingestion_worker.py
+++ b/tests/test_ingestion_worker.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from app.clients import (
+    ContentResult,
+    JobFailedError,
+    KnowledgeResult,
+    NewsItem,
+    ResolvedEntity,
+    Topic,
+)
+from app.config import Settings
+from app.ingestion import worker as worker_module
+from app.ingestion.store import PendingArticle
+
+
+@pytest.fixture
+def settings(monkeypatch: pytest.MonkeyPatch) -> Settings:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "test-key")
+    monkeypatch.setenv(
+        "NEWS_EXTRACTION_SUBMIT_URL", "https://cf/news-submit"
+    )
+    monkeypatch.setenv("NEWS_EXTRACTION_POLL_URL", "https://cf/news-poll")
+    monkeypatch.setenv(
+        "URL_CONTENT_EXTRACTION_SUBMIT_URL", "https://cf/url-submit"
+    )
+    monkeypatch.setenv("URL_CONTENT_EXTRACTION_POLL_URL", "https://cf/url-poll")
+    monkeypatch.setenv(
+        "KNOWLEDGE_EXTRACTION_SUBMIT_URL", "https://cf/kn-submit"
+    )
+    monkeypatch.setenv("KNOWLEDGE_EXTRACTION_POLL_URL", "https://cf/kn-poll")
+    for key in (
+        "OPENAI_MODEL_ARTICLE_DATA_AGENT",
+        "OPENAI_MODEL_STORY_CLUSTER_AGENT",
+        "OPENAI_MODEL_EDITORIAL_ORCHESTRATOR_AGENT",
+        "OPENAI_MODEL_ARTICLE_WRITER_AGENT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    return Settings(_env_file=None)
+
+
+class _FakeStore:
+    def __init__(self) -> None:
+        self.inserted: list[list[NewsItem]] = []
+        self.content_updates: list[tuple[str, ContentResult]] = []
+        self.knowledge_updates: list[tuple[str, KnowledgeResult]] = []
+        self.failures: list[tuple[str, dict[str, Any]]] = []
+        self.pending_by_status: dict[str, list[PendingArticle]] = {}
+        self.watermarks: dict[str, datetime] = {}
+        self.watermark_writes: list[dict[str, datetime]] = []
+        self.closed = False
+
+    async def insert_discovered(self, items: list[NewsItem]) -> int:
+        self.inserted.append(items)
+        return len(items)
+
+    async def read_watermarks(self) -> dict[str, datetime]:
+        return dict(self.watermarks)
+
+    async def upsert_watermarks(self, watermarks: dict[str, datetime]) -> None:
+        self.watermark_writes.append(dict(watermarks))
+        self.watermarks.update(watermarks)
+
+    async def list_pending(
+        self, *, status: str, limit: int = 100
+    ) -> list[PendingArticle]:
+        return self.pending_by_status.get(status, [])
+
+    async def update_content(self, article_id: str, result: ContentResult) -> None:
+        self.content_updates.append((article_id, result))
+
+    async def update_knowledge(self, article_id: str, result: KnowledgeResult) -> None:
+        self.knowledge_updates.append((article_id, result))
+
+    async def mark_failed(self, article_id: str, error: dict[str, Any]) -> None:
+        self.failures.append((article_id, error))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeNewsClient:
+    def __init__(self, items: list[NewsItem]) -> None:
+        self._items = items
+        self.closed = False
+
+    async def extract(self, **kwargs: Any) -> list[NewsItem]:
+        self.last_kwargs = kwargs
+        return self._items
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeContentClient:
+    def __init__(self, by_url: dict[str, ContentResult]) -> None:
+        self._by_url = by_url
+        self.closed = False
+
+    async def extract(self, urls: list[str], **kwargs: Any) -> dict[str, ContentResult]:
+        self.last_urls = urls
+        return {u: self._by_url[u] for u in urls if u in self._by_url}
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeKnowledgeClient:
+    def __init__(self, by_id: dict[str, KnowledgeResult | Exception]) -> None:
+        self._by_id = by_id
+        self.closed = False
+
+    async def extract(
+        self, *, article_id: str, text: str, title: str | None, url: str | None
+    ) -> KnowledgeResult:
+        value = self._by_id[article_id]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class TestRunIngestionCycle:
+    async def test_full_pipeline_happy_path(
+        self, settings: Settings, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        news_items = [
+            NewsItem(
+                url="https://ex.com/a",
+                title="A",
+                description=None,
+                publication_date=datetime(2026, 4, 23, tzinfo=UTC),
+                source_name="ESPN",
+                publisher=None,
+            ),
+        ]
+        content_by_url = {
+            "https://ex.com/a": ContentResult(
+                url="https://ex.com/a",
+                title="A",
+                content="body text",
+                paragraphs=["body text"],
+                error=None,
+            ),
+        }
+        knowledge_by_id = {
+            "art-1": KnowledgeResult(
+                topics=[Topic(topic="trade", confidence=0.9, rank=1)],
+                entities=[
+                    ResolvedEntity(
+                        entity_type="player",
+                        entity_id="00-0026158",
+                        mention_text="Josh Allen",
+                        matched_name="Josh Allen",
+                        confidence=0.98,
+                        team_abbr="BUF",
+                        position="QB",
+                    )
+                ],
+            ),
+        }
+
+        store = _FakeStore()
+        store.pending_by_status["discovered"] = [
+            PendingArticle(
+                id="art-1", url="https://ex.com/a", title="A", content=None
+            )
+        ]
+        store.pending_by_status["content_ok"] = [
+            PendingArticle(
+                id="art-1",
+                url="https://ex.com/a",
+                title="A",
+                content="body text",
+            )
+        ]
+        news_client = _FakeNewsClient(news_items)
+        content_client = _FakeContentClient(content_by_url)
+        knowledge_client = _FakeKnowledgeClient(knowledge_by_id)
+
+        monkeypatch.setattr(worker_module, "RawArticleStore", lambda **_: store)
+        monkeypatch.setattr(
+            worker_module, "NewsExtractionClient", lambda **_: news_client
+        )
+        monkeypatch.setattr(
+            worker_module, "UrlContentClient", lambda **_: content_client
+        )
+        monkeypatch.setattr(
+            worker_module, "KnowledgeExtractionClient", lambda **_: knowledge_client
+        )
+
+        summary = await worker_module.run_ingestion_cycle(settings)
+
+        assert summary.discovered == 1
+        assert summary.content_updated == 1
+        assert summary.content_failed == 0
+        assert summary.knowledge_updated == 1
+        assert summary.knowledge_failed == 0
+        assert len(store.content_updates) == 1
+        assert len(store.knowledge_updates) == 1
+        assert store.closed is True
+        assert news_client.closed is True
+        assert content_client.closed is True
+        assert knowledge_client.closed is True
+
+    async def test_watermarks_advance_and_drive_since(
+        self, settings: Settings, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Watermark flow: initial run uses 6h fallback; subsequent run
+        uses min(watermarks) - 15min rewind; only forward-moving sources
+        get written."""
+        existing_espn_mark = datetime(2026, 4, 23, 10, 0, tzinfo=UTC)
+        existing_cbs_mark = datetime(2026, 4, 23, 11, 0, tzinfo=UTC)
+
+        store = _FakeStore()
+        store.watermarks = {
+            "ESPN": existing_espn_mark,
+            "CBSSports": existing_cbs_mark,
+        }
+
+        news_items = [
+            NewsItem(  # advances ESPN
+                url="https://espn.com/a",
+                title=None,
+                description=None,
+                publication_date=datetime(2026, 4, 23, 12, 30, tzinfo=UTC),
+                source_name="ESPN",
+                publisher=None,
+            ),
+            NewsItem(  # older than existing ESPN mark → should NOT write
+                url="https://espn.com/b",
+                title=None,
+                description=None,
+                publication_date=datetime(2026, 4, 23, 9, 0, tzinfo=UTC),
+                source_name="ESPN",
+                publisher=None,
+            ),
+            NewsItem(  # new source entirely → should write
+                url="https://nfl.com/c",
+                title=None,
+                description=None,
+                publication_date=datetime(2026, 4, 23, 13, 0, tzinfo=UTC),
+                source_name="NFL",
+                publisher=None,
+            ),
+            NewsItem(  # missing pub_date → ignored for watermark
+                url="https://cbs.com/d",
+                title=None,
+                description=None,
+                publication_date=None,
+                source_name="CBSSports",
+                publisher=None,
+            ),
+        ]
+        news_client = _FakeNewsClient(news_items)
+
+        monkeypatch.setattr(worker_module, "RawArticleStore", lambda **_: store)
+        monkeypatch.setattr(
+            worker_module, "NewsExtractionClient", lambda **_: news_client
+        )
+        monkeypatch.setattr(
+            worker_module, "UrlContentClient", lambda **_: _FakeContentClient({})
+        )
+        monkeypatch.setattr(
+            worker_module,
+            "KnowledgeExtractionClient",
+            lambda **_: _FakeKnowledgeClient({}),
+        )
+
+        await worker_module.run_ingestion_cycle(settings)
+
+        # `since` = min(ESPN=10:00, CBSSports=11:00) - 15min = 09:45
+        assert news_client.last_kwargs["since"] == existing_espn_mark - timedelta(
+            minutes=15
+        )
+
+        assert len(store.watermark_writes) == 1
+        written = store.watermark_writes[0]
+        # ESPN advanced to 12:30; new source NFL appeared.
+        assert written["ESPN"] == datetime(2026, 4, 23, 12, 30, tzinfo=UTC)
+        assert written["NFL"] == datetime(2026, 4, 23, 13, 0, tzinfo=UTC)
+        # CBSSports was never advanced (no item with a pub_date for it).
+        assert "CBSSports" not in written
+
+    async def test_first_run_uses_6h_fallback(
+        self, settings: Settings, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = _FakeStore()  # no watermarks
+        news_client = _FakeNewsClient([])
+
+        monkeypatch.setattr(worker_module, "RawArticleStore", lambda **_: store)
+        monkeypatch.setattr(
+            worker_module, "NewsExtractionClient", lambda **_: news_client
+        )
+        monkeypatch.setattr(
+            worker_module, "UrlContentClient", lambda **_: _FakeContentClient({})
+        )
+        monkeypatch.setattr(
+            worker_module,
+            "KnowledgeExtractionClient",
+            lambda **_: _FakeKnowledgeClient({}),
+        )
+
+        before = datetime.now(UTC)
+        await worker_module.run_ingestion_cycle(settings)
+        after = datetime.now(UTC)
+
+        since = news_client.last_kwargs["since"]
+        assert before - timedelta(hours=6, seconds=1) <= since <= after - timedelta(
+            hours=5, minutes=59
+        )
+
+    async def test_content_missing_from_batch_marks_failed(
+        self, settings: Settings, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = _FakeStore()
+        store.pending_by_status["discovered"] = [
+            PendingArticle(id="x", url="https://ex.com/x", title=None, content=None),
+        ]
+        news_client = _FakeNewsClient([])
+        content_client = _FakeContentClient({})  # empty response
+        knowledge_client = _FakeKnowledgeClient({})
+
+        monkeypatch.setattr(worker_module, "RawArticleStore", lambda **_: store)
+        monkeypatch.setattr(
+            worker_module, "NewsExtractionClient", lambda **_: news_client
+        )
+        monkeypatch.setattr(
+            worker_module, "UrlContentClient", lambda **_: content_client
+        )
+        monkeypatch.setattr(
+            worker_module, "KnowledgeExtractionClient", lambda **_: knowledge_client
+        )
+
+        summary = await worker_module.run_ingestion_cycle(settings)
+        assert summary.content_failed == 1
+        assert store.failures[0][1]["stage"] == "content"
+
+    async def test_knowledge_failure_marks_row_failed(
+        self, settings: Settings, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = _FakeStore()
+        store.pending_by_status["content_ok"] = [
+            PendingArticle(id="y", url="u", title="t", content="body")
+        ]
+        monkeypatch.setattr(worker_module, "RawArticleStore", lambda **_: store)
+        monkeypatch.setattr(
+            worker_module, "NewsExtractionClient", lambda **_: _FakeNewsClient([])
+        )
+        monkeypatch.setattr(
+            worker_module, "UrlContentClient", lambda **_: _FakeContentClient({})
+        )
+        monkeypatch.setattr(
+            worker_module,
+            "KnowledgeExtractionClient",
+            lambda **_: _FakeKnowledgeClient({"y": JobFailedError("LLM down")}),
+        )
+
+        summary = await worker_module.run_ingestion_cycle(settings)
+        assert summary.knowledge_failed == 1
+        assert store.failures[-1][1]["stage"] == "knowledge"
+
+    async def test_missing_config_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "test-key")
+        for var in (
+            "NEWS_EXTRACTION_SUBMIT_URL",
+            "NEWS_EXTRACTION_POLL_URL",
+            "URL_CONTENT_EXTRACTION_SUBMIT_URL",
+            "URL_CONTENT_EXTRACTION_POLL_URL",
+            "KNOWLEDGE_EXTRACTION_SUBMIT_URL",
+            "KNOWLEDGE_EXTRACTION_POLL_URL",
+            "OPENAI_MODEL_ARTICLE_DATA_AGENT",
+            "OPENAI_MODEL_STORY_CLUSTER_AGENT",
+            "OPENAI_MODEL_EDITORIAL_ORCHESTRATOR_AGENT",
+            "OPENAI_MODEL_ARTICLE_WRITER_AGENT",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        s = Settings(_env_file=None)
+        with pytest.raises(RuntimeError, match="NEWS_EXTRACTION_SUBMIT_URL"):
+            await worker_module.run_ingestion_cycle(s)


### PR DESCRIPTION
## Summary

- Replace the legacy Supabase-edge-function feed + article-lookup with a first-party ingestion pipeline chaining three Google Cloud Functions (news → URL content → knowledge) into a fresh Supabase project; editorial cycle adapters now read from `public.raw_articles` + `article_entities` with the same `RawArticle` shape downstream.
- New `ingestion-worker` entry point (separate `*/30` GitHub Actions cron) with per-source watermarks (`public.ingestion_watermarks`, 15-min rewind buffer) replacing `LOOKBACK_HOURS`; watermarks advance at discovery so content/knowledge failures never block future windows.
- Consolidate onto `public` schema (drop `content.*`, strip `Content-Profile` / `Accept-Profile` headers); 10 v2 migrations cover extraction_jobs + RPC, raw_articles, article_entities/topics, editorial_state, team_article, curated_images, article_images, ingestion_watermarks.

## Test plan

- [x] Rotate 9 required secrets (`OPENAI_API_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, 6 CF URLs) + delete legacy 3 (`SUPABASE_NEWS_FEED_URL` / `SUPABASE_ARTICLE_LOOKUP_URL` / `SUPABASE_FUNCTION_AUTH_TOKEN`)
- [ ] `workflow_dispatch` the `ingestion-worker` workflow once; verify summary `{"discovered": N, "content_updated": N, "knowledge_updated": N}` in the run log and fresh rows in `public.raw_articles` / `article_entities` / `article_topics`
- [ ] Inspect `public.ingestion_watermarks` for one row per source with a recent `last_publication_at`
- [ ] `workflow_dispatch` the `editorial-cycle` workflow; verify `var/output.json` artifact, and new rows in `public.team_article` (en-US + de-DE) and `public.editorial_state`
- [ ] Confirm curated image URLs render (tier-3 cascade) — open any `image` field from `team_article` in a browser
- [ ] Let both schedules fire naturally (`*/30` + `0 */2 * * *`) for one full cycle; check both runs stay green
- [ ] `./venv/bin/pytest tests/ -v` locally — expect 149 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)