### PR TITLE
fix: dedupe entities/topics before PostgREST upsert

### DIFF
--- a/app/ingestion/store.py
+++ b/app/ingestion/store.py
@@ -163,8 +163,11 @@ class RawArticleStore:
     ) -> None:
         """Write entities + topics, flip status to knowledge_ok."""
         if result.entities:
-            entity_rows = [
-                {
+            entity_rows_by_key: dict[tuple[str, str, str], dict] = {}
+            for e in result.entities:
+                if not (e.entity_type and e.entity_id):
+                    continue
+                row = {
                     "article_id": article_id,
                     "entity_type": e.entity_type,
                     "entity_id": e.entity_id,
@@ -174,9 +177,11 @@ class RawArticleStore:
                     "team_abbr": e.team_abbr,
                     "position": e.position,
                 }
-                for e in result.entities
-                if e.entity_type and e.entity_id
-            ]
+                key = (article_id, e.entity_type, e.entity_id)
+                prev = entity_rows_by_key.get(key)
+                if prev is None or (row["confidence"] or 0) > (prev["confidence"] or 0):
+                    entity_rows_by_key[key] = row
+            entity_rows = list(entity_rows_by_key.values())
             if entity_rows:
                 response = await self._client.post(
                     "/rest/v1/article_entities",
@@ -193,16 +198,21 @@ class RawArticleStore:
                     )
 
         if result.topics:
-            topic_rows = [
-                {
+            topic_rows_by_key: dict[tuple[str, str], dict] = {}
+            for t in result.topics:
+                if not t.topic:
+                    continue
+                row = {
                     "article_id": article_id,
                     "topic": t.topic,
                     "confidence": t.confidence,
                     "rank": t.rank,
                 }
-                for t in result.topics
-                if t.topic
-            ]
+                key = (article_id, t.topic)
+                prev = topic_rows_by_key.get(key)
+                if prev is None or (row["confidence"] or 0) > (prev["confidence"] or 0):
+                    topic_rows_by_key[key] = row
+            topic_rows = list(topic_rows_by_key.values())
             if topic_rows:
                 response = await self._client.post(
                     "/rest/v1/article_topics",

--- a/changelog/changelog_2026-04-24.md
+++ b/changelog/changelog_2026-04-24.md
@@ -1,0 +1,28 @@
+# Changelog — 2026-04-24
+
+## Summary
+Diagnosed and fixed a production crash in the ingestion worker where PostgREST returned SQLSTATE 21000 on upserts to `article_entities` and `article_topics`. The knowledge-extraction LLM can emit duplicate entities or topics for the same article within a single batch; the fix deduplicates rows client-side before the POST so every conflict-target key is unique within the statement.
+
+## Changes
+- **fix: deduplicate entities and topics in `update_knowledge` before upsert**
+  - `article_entities` deduplicated by `(article_id, entity_type, entity_id)` — the table PK
+  - `article_topics` deduplicated by `(article_id, topic)` — the table PK
+  - On collision within a batch, the row with the higher `confidence` is kept (`None` treated as 0)
+  - Prevents PostgREST SQLSTATE 21000 "ON CONFLICT DO UPDATE command cannot affect row a second time"
+- **test: add `test_update_knowledge_dedupes_entities_and_topics`**
+  - Covers the entity-dedup path (two rows for the same player, different confidence — higher wins)
+  - Covers the topic-dedup path (two rows for the same topic, different confidence — higher wins)
+  - Uses the existing `httpx.MockTransport` pattern consistent with the rest of the test module
+
+## Files Modified
+- `app/ingestion/store.py` — `update_knowledge()` now builds `entity_rows_by_key` and `topic_rows_by_key` dicts keyed on the respective PKs, keeping the highest-confidence row per key before POSTing
+- `tests/test_ingestion_store.py` — added `test_update_knowledge_dedupes_entities_and_topics` (7 → 7 passing; new test is item 6 of 7)
+
+## Code Quality Notes
+- Tests: 150 passed, 0 failed, 0 skipped (full suite)
+- No debug artifacts, TODO/FIXME markers, or commented-out blocks found in changed files
+- No linting step configured for the Python backend (no `ruff`/`flake8` entry in `pyproject.toml` scripts)
+
+## Open Items / Carry-over
+- Migration `007_add_story_fingerprint.sql` remains **pending** (noted in CLAUDE.md — pre-existing carry-over)
+- The untracked files `scripts/architecture_graph_manual.yml`, `scripts/build_architecture_graph.py`, and `tests/test_architecture_graph.py` are not part of today's fix; they were excluded from this commit intentionally

--- a/tests/test_ingestion_store.py
+++ b/tests/test_ingestion_store.py
@@ -150,6 +150,54 @@ class TestRawArticleStore:
         assert any("article_topics" in p for p in paths)
         assert methods.count("PATCH") == 1
 
+    async def test_update_knowledge_dedupes_entities_and_topics(self) -> None:
+        captured: dict[str, list] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if "article_entities" in request.url.path:
+                captured["entities"] = _json.loads(request.read())
+            elif "article_topics" in request.url.path:
+                captured["topics"] = _json.loads(request.read())
+            return httpx.Response(204 if request.method == "PATCH" else 201, json=[])
+
+        store = _store_with_handler(handler)
+        await store.update_knowledge(
+            "article-1",
+            KnowledgeResult(
+                topics=[
+                    Topic(topic="trade", confidence=0.7, rank=2),
+                    Topic(topic="trade", confidence=0.9, rank=1),
+                ],
+                entities=[
+                    ResolvedEntity(
+                        entity_type="player",
+                        entity_id="00-0026158",
+                        mention_text="Josh",
+                        matched_name="Josh Allen",
+                        confidence=0.6,
+                        team_abbr="BUF",
+                        position="QB",
+                    ),
+                    ResolvedEntity(
+                        entity_type="player",
+                        entity_id="00-0026158",
+                        mention_text="Josh Allen",
+                        matched_name="Josh Allen",
+                        confidence=0.95,
+                        team_abbr="BUF",
+                        position="QB",
+                    ),
+                ],
+                unresolved_entities=[],
+            ),
+        )
+        await store.close()
+
+        assert len(captured["entities"]) == 1
+        assert captured["entities"][0]["confidence"] == 0.95
+        assert len(captured["topics"]) == 1
+        assert captured["topics"][0]["confidence"] == 0.9
+
     async def test_update_knowledge_skips_empty_buckets(self) -> None:
         calls: list[tuple[str, str]] = []
 


### PR DESCRIPTION
## Summary
- Fixes ingestion-worker crash with Postgres SQLSTATE 21000: *"ON CONFLICT DO UPDATE command cannot affect row a second time"* when writing `article_entities` / `article_topics`.
- Root cause: the knowledge-extraction LLM can return the same entity/topic twice for one article; PostgREST upsert rejects duplicate conflict-target rows within a single statement.
- `RawArticleStore.update_knowledge` now dedupes each batch on the table's primary key before POSTing — keeping the higher-confidence row on collision.

## Changes
- `app/ingestion/store.py` — dedupe `article_entities` on `(article_id, entity_type, entity_id)` and `article_topics` on `(article_id, topic)`.
- `tests/test_ingestion_store.py` — new `test_update_knowledge_dedupes_entities_and_topics` covering both paths.

## Test plan
- [x] `./venv/bin/pytest tests/test_ingestion_store.py -v` — 7/7 pass
- [x] Full suite — 150/150 pass
- [ ] Observe next scheduled ingestion cycle; confirm no more 21000 errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)