### PR TITLE
Parallelize knowledge extraction with configurable cap (#9)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -35,6 +35,7 @@ class Settings(BaseSettings):
     # verifies in its own runtime env — not a Supabase/OpenAI credential.
     extraction_function_auth_token: SecretStr | None = None
     ingestion_max_articles_per_run: int = 200
+    ingestion_knowledge_max_concurrency: int = 4
 
     top_n: int = 5
     lookback_hours: int = 2

--- a/app/ingestion/worker.py
+++ b/app/ingestion/worker.py
@@ -13,6 +13,7 @@ and crash-safe: reruns pick up wherever the previous run left off.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -100,7 +101,9 @@ async def run_ingestion_cycle(settings: Settings) -> IngestionSummary:
             store=store, content_client=content_client
         )
         summary.knowledge_updated, summary.knowledge_failed = await _extract_knowledge(
-            store=store, knowledge_client=knowledge_client
+            store=store,
+            knowledge_client=knowledge_client,
+            max_concurrency=settings.ingestion_knowledge_max_concurrency,
         )
     finally:
         await store.close()
@@ -216,6 +219,7 @@ async def _extract_knowledge(
     *,
     store: RawArticleStore,
     knowledge_client: KnowledgeExtractionClient,
+    max_concurrency: int,
 ) -> tuple[int, int]:
     pending: list[PendingArticle] = await store.list_pending(
         status="content_ok", limit=_CONTENT_BATCH_SIZE
@@ -223,30 +227,53 @@ async def _extract_knowledge(
     if not pending:
         return 0, 0
 
-    ok, failed = 0, 0
-    for p in pending:
-        if not p.content:
-            await store.mark_failed(
-                p.id, {"stage": "knowledge", "error": "content_ok row has no content"}
+    semaphore = asyncio.Semaphore(max(1, max_concurrency))
+
+    async def _process_one(p: PendingArticle) -> bool:
+        async with semaphore:
+            if not p.content:
+                await store.mark_failed(
+                    p.id,
+                    {"stage": "knowledge", "error": "content_ok row has no content"},
+                )
+                return False
+            try:
+                result = await knowledge_client.extract(
+                    article_id=p.id,
+                    text=p.content,
+                    title=p.title,
+                    url=p.url,
+                )
+            except (JobFailedError, JobTimeoutError) as exc:
+                logger.warning("knowledge extraction failed for %s: %s", p.id, exc)
+                await store.mark_failed(
+                    p.id, {"stage": "knowledge", "error": str(exc)}
+                )
+                return False
+            await store.update_knowledge(p.id, result)
+            return True
+
+    # return_exceptions=True ensures one task crashing (e.g., an unexpected
+    # error type not in the JobFailed/JobTimeout pair) does not cancel the
+    # rest. Such crashes are logged and counted as failed for that row,
+    # without an attempt to mark_failed (we don't know if mark_failed itself
+    # was the failure).
+    results = await asyncio.gather(
+        *(_process_one(p) for p in pending),
+        return_exceptions=True,
+    )
+    ok = 0
+    failed = 0
+    for p, r in zip(pending, results, strict=True):
+        if isinstance(r, BaseException):
+            logger.exception(
+                "Unexpected error processing knowledge for %s", p.id, exc_info=r
             )
             failed += 1
-            continue
-        try:
-            result = await knowledge_client.extract(
-                article_id=p.id,
-                text=p.content,
-                title=p.title,
-                url=p.url,
-            )
-        except (JobFailedError, JobTimeoutError) as exc:
-            logger.warning("knowledge extraction failed for %s: %s", p.id, exc)
-            await store.mark_failed(
-                p.id, {"stage": "knowledge", "error": str(exc)}
-            )
+        elif r:
+            ok += 1
+        else:
             failed += 1
-            continue
-        await store.update_knowledge(p.id, result)
-        ok += 1
     return ok, failed
 
 

--- a/tests/test_ingestion_worker.py
+++ b/tests/test_ingestion_worker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -113,17 +114,32 @@ class _FakeContentClient:
 
 
 class _FakeKnowledgeClient:
-    def __init__(self, by_id: dict[str, KnowledgeResult | Exception]) -> None:
+    def __init__(
+        self,
+        by_id: dict[str, KnowledgeResult | Exception],
+        *,
+        delay_seconds: float = 0.0,
+    ) -> None:
         self._by_id = by_id
+        self._delay_seconds = delay_seconds
         self.closed = False
+        self.in_flight = 0
+        self.max_in_flight = 0
 
     async def extract(
         self, *, article_id: str, text: str, title: str | None, url: str | None
     ) -> KnowledgeResult:
-        value = self._by_id[article_id]
-        if isinstance(value, Exception):
-            raise value
-        return value
+        self.in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self.in_flight)
+        try:
+            if self._delay_seconds:
+                await asyncio.sleep(self._delay_seconds)
+            value = self._by_id[article_id]
+            if isinstance(value, Exception):
+                raise value
+            return value
+        finally:
+            self.in_flight -= 1
 
     async def close(self) -> None:
         self.closed = True
@@ -368,6 +384,146 @@ class TestRunIngestionCycle:
         summary = await worker_module.run_ingestion_cycle(settings)
         assert summary.knowledge_failed == 1
         assert store.failures[-1][1]["stage"] == "knowledge"
+
+    async def test_knowledge_concurrent_mixed_success_failure(
+        self, settings: Settings, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Multiple pending rows process in parallel; per-row failures
+        don't cancel other rows; final counts are deterministic."""
+        store = _FakeStore()
+        store.pending_by_status["content_ok"] = [
+            PendingArticle(id=f"art-{i}", url=f"u{i}", title="t", content="body")
+            for i in range(6)
+        ]
+        knowledge_payload = KnowledgeResult(topics=[], entities=[])
+        by_id: dict[str, KnowledgeResult | Exception] = {
+            "art-0": knowledge_payload,
+            "art-1": JobFailedError("boom"),
+            "art-2": knowledge_payload,
+            "art-3": JobFailedError("nope"),
+            "art-4": knowledge_payload,
+            "art-5": knowledge_payload,
+        }
+        knowledge_client = _FakeKnowledgeClient(by_id, delay_seconds=0.02)
+
+        monkeypatch.setattr(worker_module, "RawArticleStore", lambda **_: store)
+        monkeypatch.setattr(
+            worker_module, "NewsExtractionClient", lambda **_: _FakeNewsClient([])
+        )
+        monkeypatch.setattr(
+            worker_module, "UrlContentClient", lambda **_: _FakeContentClient({})
+        )
+        monkeypatch.setattr(
+            worker_module, "KnowledgeExtractionClient", lambda **_: knowledge_client
+        )
+
+        summary = await worker_module.run_ingestion_cycle(settings)
+
+        assert summary.knowledge_updated == 4
+        assert summary.knowledge_failed == 2
+        updated_ids = {aid for aid, _ in store.knowledge_updates}
+        assert updated_ids == {"art-0", "art-2", "art-4", "art-5"}
+        failed_ids = {
+            aid for aid, err in store.failures if err.get("stage") == "knowledge"
+        }
+        assert failed_ids == {"art-1", "art-3"}
+
+    async def test_knowledge_respects_concurrency_cap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In-flight count never exceeds ingestion_knowledge_max_concurrency."""
+        cap = 3
+        n = 8
+        # Set required env then override the cap.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "test-key")
+        monkeypatch.setenv("NEWS_EXTRACTION_SUBMIT_URL", "https://cf/news-submit")
+        monkeypatch.setenv("NEWS_EXTRACTION_POLL_URL", "https://cf/news-poll")
+        monkeypatch.setenv(
+            "URL_CONTENT_EXTRACTION_SUBMIT_URL", "https://cf/url-submit"
+        )
+        monkeypatch.setenv("URL_CONTENT_EXTRACTION_POLL_URL", "https://cf/url-poll")
+        monkeypatch.setenv("KNOWLEDGE_EXTRACTION_SUBMIT_URL", "https://cf/kn-submit")
+        monkeypatch.setenv("KNOWLEDGE_EXTRACTION_POLL_URL", "https://cf/kn-poll")
+        monkeypatch.setenv("EXTRACTION_FUNCTION_AUTH_TOKEN", "test-fn-token")
+        monkeypatch.setenv("INGESTION_KNOWLEDGE_MAX_CONCURRENCY", str(cap))
+        for key in (
+            "OPENAI_MODEL_ARTICLE_DATA_AGENT",
+            "OPENAI_MODEL_STORY_CLUSTER_AGENT",
+            "OPENAI_MODEL_EDITORIAL_ORCHESTRATOR_AGENT",
+            "OPENAI_MODEL_ARTICLE_WRITER_AGENT",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        s = Settings(_env_file=None)
+        assert s.ingestion_knowledge_max_concurrency == cap
+
+        store = _FakeStore()
+        store.pending_by_status["content_ok"] = [
+            PendingArticle(id=f"a{i}", url=f"u{i}", title="t", content="body")
+            for i in range(n)
+        ]
+        payload = KnowledgeResult(topics=[], entities=[])
+        knowledge_client = _FakeKnowledgeClient(
+            {f"a{i}": payload for i in range(n)},
+            delay_seconds=0.05,
+        )
+
+        monkeypatch.setattr(worker_module, "RawArticleStore", lambda **_: store)
+        monkeypatch.setattr(
+            worker_module, "NewsExtractionClient", lambda **_: _FakeNewsClient([])
+        )
+        monkeypatch.setattr(
+            worker_module, "UrlContentClient", lambda **_: _FakeContentClient({})
+        )
+        monkeypatch.setattr(
+            worker_module, "KnowledgeExtractionClient", lambda **_: knowledge_client
+        )
+
+        summary = await worker_module.run_ingestion_cycle(s)
+
+        assert summary.knowledge_updated == n
+        assert summary.knowledge_failed == 0
+        # Cap respected, AND we did go above 1 (proves parallelism).
+        assert knowledge_client.max_in_flight <= cap
+        assert knowledge_client.max_in_flight > 1
+
+    async def test_knowledge_unexpected_exception_does_not_cancel_siblings(
+        self, settings: Settings, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unexpected exception (not JobFailed/JobTimeout) for one row
+        must be counted as failed without breaking the others."""
+        store = _FakeStore()
+        store.pending_by_status["content_ok"] = [
+            PendingArticle(id="ok-1", url="u1", title="t", content="body"),
+            PendingArticle(id="boom", url="u2", title="t", content="body"),
+            PendingArticle(id="ok-2", url="u3", title="t", content="body"),
+        ]
+        payload = KnowledgeResult(topics=[], entities=[])
+        knowledge_client = _FakeKnowledgeClient(
+            {
+                "ok-1": payload,
+                "boom": RuntimeError("unexpected"),
+                "ok-2": payload,
+            }
+        )
+
+        monkeypatch.setattr(worker_module, "RawArticleStore", lambda **_: store)
+        monkeypatch.setattr(
+            worker_module, "NewsExtractionClient", lambda **_: _FakeNewsClient([])
+        )
+        monkeypatch.setattr(
+            worker_module, "UrlContentClient", lambda **_: _FakeContentClient({})
+        )
+        monkeypatch.setattr(
+            worker_module, "KnowledgeExtractionClient", lambda **_: knowledge_client
+        )
+
+        summary = await worker_module.run_ingestion_cycle(settings)
+        assert summary.knowledge_updated == 2
+        assert summary.knowledge_failed == 1
+        updated_ids = {aid for aid, _ in store.knowledge_updates}
+        assert updated_ids == {"ok-1", "ok-2"}
 
     async def test_missing_config_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")


### PR DESCRIPTION
Closes #9.

## Summary
- Knowledge extraction now processes pending `content_ok` rows in parallel under a configurable concurrency cap.
- Per-article success/failure handling preserved; one bad row no longer cancels its siblings.

## Changes
- `app/config.py`: new `ingestion_knowledge_max_concurrency: int = 4` (conservative default; override via \`INGESTION_KNOWLEDGE_MAX_CONCURRENCY\`).
- `app/ingestion/worker.py`: `_extract_knowledge` refactored around \`asyncio.gather\` + \`asyncio.Semaphore\`. Unexpected exception types (outside \`JobFailedError\`/\`JobTimeoutError\`) are now logged + counted as failed instead of crashing the whole stage.
- `tests/test_ingestion_worker.py`:
  - `test_knowledge_concurrent_mixed_success_failure` — 6 rows, 2 fail, 4 succeed, deterministic counts.
  - `test_knowledge_respects_concurrency_cap` — cap=3 with 8 rows; asserts `max_in_flight ≤ 3` AND `max_in_flight > 1` (proves cap + parallelism).
  - `test_knowledge_unexpected_exception_does_not_cancel_siblings` — `RuntimeError` for one row leaves the other two successful.
- Existing tests (incl. \`_FakeKnowledgeClient\`) updated minimally; new constructor kwarg \`delay_seconds\` is optional with default 0 — no behavior change for older tests.

## Acceptance criteria
- [x] Multiple pending \`content_ok\` rows process in parallel
- [x] Failures for one article don't cancel successful updates for others
- [x] Concurrency cap is configurable and defaults conservatively (4)
- [x] Tests cover mixed success/failure concurrent extraction

## Out-of-scope (per issue)
- No change to cloud function contract.
- No change to \`_CONTENT_BATCH_SIZE\`.

## Test plan
- [x] \`./venv/bin/pytest tests/test_ingestion_worker.py -v\` (9 passed)
- [x] \`./venv/bin/pytest tests/\` (178 passed)
- [ ] Live cycle dry-run: monitor real Cloud Run latency / error rate at default cap=4 before considering raising it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)