### PR TITLE
Add editorial quality gate and memory

### DIFF
--- a/.github/workflows/editorial-cycle.yml
+++ b/.github/workflows/editorial-cycle.yml
@@ -22,6 +22,9 @@ concurrency:
   group: editorial-cycle
   cancel-in-progress: false
 
+permissions:
+  contents: write
+
 jobs:
   run:
     runs-on: ubuntu-latest
@@ -73,11 +76,39 @@ jobs:
           if [ -n "${{ vars.OPENAI_MODEL_PERSONA_SELECTOR_AGENT }}" ]; then
             export OPENAI_MODEL_PERSONA_SELECTOR_AGENT="${{ vars.OPENAI_MODEL_PERSONA_SELECTOR_AGENT }}"
           fi
+          if [ -n "${{ vars.OPENAI_MODEL_ARTICLE_QUALITY_GATE_AGENT }}" ]; then
+            export OPENAI_MODEL_ARTICLE_QUALITY_GATE_AGENT="${{ vars.OPENAI_MODEL_ARTICLE_QUALITY_GATE_AGENT }}"
+          fi
+          if [ -n "${{ vars.OPENAI_MODEL_EDITORIAL_MEMORY_AGENT }}" ]; then
+            export OPENAI_MODEL_EDITORIAL_MEMORY_AGENT="${{ vars.OPENAI_MODEL_EDITORIAL_MEMORY_AGENT }}"
+          fi
           if [ -n "${{ vars.OPENAI_MODEL_VISION_VALIDATOR }}" ]; then
             export OPENAI_MODEL_VISION_VALIDATOR="${{ vars.OPENAI_MODEL_VISION_VALIDATOR }}"
           fi
           mkdir -p var
           editorial-cycle run --output-json var/output.json
+
+      - name: Persist editorial memory
+        if: always()
+        run: |
+          set -euo pipefail
+          if ! git status --short -- editorial_memory | grep -q .; then
+            echo "No editorial memory changes to persist."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add editorial_memory
+
+          if git diff --cached --quiet; then
+            echo "No staged editorial memory changes."
+            exit 0
+          fi
+
+          git commit -m "Update editorial memory from cycle ${{ github.run_id }}"
+          git pull --rebase --autostash
+          git push
 
       - name: Upload cycle artifacts
         if: always()

--- a/.github/workflows/editorial-cycle.yml
+++ b/.github/workflows/editorial-cycle.yml
@@ -32,6 +32,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Sync editorial memory from data branch
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin editorial-memory >/dev/null 2>&1; then
+            git fetch origin editorial-memory --depth=1
+            git checkout origin/editorial-memory -- editorial_memory/ || true
+          else
+            echo "editorial-memory data branch does not exist yet; using checked-in seed."
+          fi
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -99,16 +109,38 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Snapshot the updated memory outside the working tree so we can
+          # apply it onto the data branch without dragging code along.
+          SNAPSHOT=$(mktemp -d)
+          cp -r editorial_memory "$SNAPSHOT/"
+
+          # Reset working tree so the branch switch is clean.
+          git checkout -- editorial_memory || true
+          git clean -fd editorial_memory || true
+
+          # Switch to the data branch (create as orphan on first run).
+          if git ls-remote --exit-code --heads origin editorial-memory >/dev/null 2>&1; then
+            git fetch origin editorial-memory
+            git switch editorial-memory
+            git pull --ff-only origin editorial-memory || true
+          else
+            git switch --orphan editorial-memory
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          # Apply snapshot onto the data branch and commit.
+          rm -rf editorial_memory
+          cp -r "$SNAPSHOT/editorial_memory" editorial_memory
           git add editorial_memory
 
           if git diff --cached --quiet; then
-            echo "No staged editorial memory changes."
+            echo "No staged editorial memory changes after sync."
             exit 0
           fi
 
           git commit -m "Update editorial memory from cycle ${{ github.run_id }}"
-          git pull --rebase --autostash
-          git push
+          git push origin editorial-memory
 
       - name: Upload cycle artifacts
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,0 +1,560 @@
+# T4L Editorial Cycle
+
+Hourly NFL editorial pipeline for Tackle4Loss. Fetches news from a Supabase
+edge-function feed, clusters by story, ranks by news value, runs each draft
+through an LLM editorial quality gate, and writes the top‑N stories to
+Supabase as paired EN + DE articles.
+
+Built on the OpenAI Agents SDK with nested agent‑tools, deterministic
+dedup layers, a four‑tier image cascade, and a markdown‑based editorial
+memory wiki that learns from the quality gate's feedback.
+
+For Claude Code's working notes (commands, conventions, gotchas), see
+[`CLAUDE.md`](./CLAUDE.md). This README is the canonical project overview.
+
+---
+
+## Table of contents
+
+1. [Quick start](#quick-start)
+2. [Pipeline overview](#pipeline-overview)
+3. [Module layout](#module-layout)
+4. [Agent chain](#agent-chain)
+5. [Entity clustering & dedup](#entity-clustering--dedup)
+6. [Editorial quality gate](#editorial-quality-gate)
+7. [Editorial memory wiki](#editorial-memory-wiki)
+8. [Image cascade](#image-cascade)
+9. [Supabase](#supabase)
+10. [Frontend edge functions](#frontend-edge-functions)
+11. [Configuration](#configuration)
+12. [Prompts](#prompts)
+13. [CI / GitHub Actions](#ci--github-actions)
+14. [Reports & tooling](#reports--tooling)
+15. [Testing](#testing)
+
+---
+
+## Quick start
+
+```bash
+# Install (editable + dev extras)
+./venv/bin/pip install -e '.[dev]'
+
+# Run a single editorial cycle (writes articles to Supabase)
+./venv/bin/editorial-cycle run --output-json var/output.json
+
+# Run all tests
+./venv/bin/pytest tests/ -v
+
+# Build the post-cycle HTML report (reads var/output.json)
+./venv/bin/python scripts/build_cycle_report.py
+
+# Build the pre-publish overview report (paired EN/DE, with state + trace)
+./venv/bin/python scripts/build_overview_report.py [--limit N]
+
+# 12-hour soak test (1 cycle/hour, logs to var/test_runs/)
+nohup ./run_12h_test.sh &
+```
+
+Required env (see [Configuration](#configuration) for the full list):
+`OPENAI_API_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`,
+`SUPABASE_NEWS_FEED_URL`, `SUPABASE_ARTICLE_LOOKUP_URL`,
+`EXTRACTION_FUNCTION_AUTH_TOKEN`.
+
+---
+
+## Pipeline overview
+
+```
+feed (Supabase edge fn)
+  → URL dedup
+  → entity clustering (player > game > team)
+  → orchestrator agent: cluster scoring + ranking + dedup vs. published_fingerprints
+  → for each top-N story:
+       EN writer ──► quality gate ──► (approve | rewrite once | dismiss)
+                          │
+                          ├─► image cascade (once per story; result reused for DE)
+                          └─► DE writer
+                          → write to Supabase content.team_article (INSERT or PATCH)
+                          → persist editorial_state (cross-cycle memory)
+```
+
+Cycle runs every 2 hours via GitHub Actions. Each story produces **two**
+`PublishableArticle` records (`en-US` + `de-DE`); the image cascade runs
+once for EN and the resulting URL/asset is reused by the DE article.
+
+The pipeline is split into two modules with a clean phase boundary —
+`editorial/` produces a `CyclePublishPlan`, `writer/` consumes it and
+emits articles. Modules share only `app/schemas.py` and `app/adapters.py`.
+
+---
+
+## Module layout
+
+```
+app/
+├── orchestration.py        # 4 lines of glue between editorial → writer
+├── editorial/
+│   ├── workflow.py         # feed → dedup → cluster → orchestrator
+│   ├── helpers.py          # entity clustering, post-orchestrator dedup
+│   ├── tools.py            # nested agent-tools (analyze_story_cluster, digest_article)
+│   ├── tracing.py          # OpenAI Agents run_config + trace metadata
+│   └── prompts.yml         # all editorial-side prompts
+├── writer/
+│   ├── workflow.py         # parallel article generation, quality gate, memory
+│   ├── agents.py           # writer, quality gate, editorial memory agent
+│   ├── editorial_memory.py # markdown read/write helpers
+│   ├── image_selector.py   # 4-tier image cascade
+│   ├── image_clients.py    # Google CC, Wikimedia, headshot, curated pool clients
+│   ├── image_validator.py  # vision-model contradiction check
+│   ├── persona_selector.py # picks one of 3 bylines per story
+│   ├── personas.py         # analyst / insider / columnist definitions
+│   └── prompts.yml         # writer + gate + memory prompts
+├── ingestion/              # ingestion worker (knowledge extraction jobs)
+├── adapters.py             # Supabase clients (state, articles, feed, lookup)
+├── schemas.py              # all Pydantic models
+├── team_codes.py           # canonicalize_team_codes, team_full_name, team_colors
+├── config.py               # pydantic-settings BaseSettings
+└── cli.py                  # `editorial-cycle` typer entry point
+
+editorial_memory/
+├── wiki/                   # coaching markdown (LLM-maintained + hand-seeded)
+└── raw_feedback/           # append-only daily event log
+
+scripts/
+├── build_cycle_report.py       # post-cycle HTML report
+├── build_overview_report.py    # all team_articles, paired EN/DE
+└── build_architecture_graph.py # generates the architecture graph
+
+tests/                      # 191+ tests (unit + integration)
+.github/workflows/          # editorial-cycle (every 2h) + ingestion-worker
+supabase/functions/         # Deno edge functions for the Flutter frontend
+```
+
+---
+
+## Agent chain
+
+Five agents wired through the OpenAI Agents SDK. Nested agent‑tools share
+trace context via `_run_nested_agent()` in `editorial/tools.py`, which
+forwards `tool_context.context` and `tool_context.run_config` to
+`Runner.run()`.
+
+```
+Editorial Cycle Orchestrator        (output: CyclePublishPlan)
+  └── analyze_story_cluster tool
+        └── Story Cluster Agent     (output: StoryClusterResult)
+              └── digest_article tool
+                    └── Article Data Agent  (output: ArticleDigestAgentResult)
+                          └── lookup_article_content tool  (Supabase edge fn)
+
+Article Writer Agent (EN)           (no tools, output: PublishableArticle)
+Article Writer Agent (DE)           (no tools, output: PublishableArticle)
+Article Quality Gate Agent          (no tools, output: ArticleQualityDecision)
+Editorial Memory Agent              (no tools, output: EditorialMemoryRevision)
+Persona Selector Agent              (no tools, output: PersonaSelection)
+```
+
+Per‑agent model IDs are configurable via `OPENAI_MODEL_*` env vars and
+resolved by `Settings.agent_model(name)`.
+
+---
+
+## Entity clustering & dedup
+
+Articles are assigned to their **most specific** entity:
+`player > game > team`. Two‑pass grouping in
+`editorial/helpers.py`:
+
+1. Group by best entity → split into multi‑source (2+ articles) and
+   pending singles.
+2. Merge singles into any existing multi‑source cluster if they share
+   ANY entity via a reverse index.
+
+This prevents the same story (e.g., a player trade) from appearing as
+both a cluster result and a standalone candidate. Only articles with zero
+entity overlap with any cluster remain as single‑source candidates.
+
+### Four deterministic dedup layers
+
+| Layer | Where | What it does |
+|---|---|---|
+| URL dedup | `deduplicate()` pre‑clustering | Removes exact URL matches |
+| Entity clustering | `helpers.py` | Groups related articles, merges singles |
+| `deduplicate_plan()` | Post‑orchestrator | Removes stories with duplicate fingerprints (keeps highest‑ranked) |
+| Cross‑cycle | `editorial_state` (Supabase) | Prior fingerprints passed to orchestrator as `published_fingerprints` |
+
+Story fingerprints are deterministic hashes; the agent's emitted
+fingerprint string is used only for logs. INSERT vs PATCH is decided per
+language via `ArticleWriter.find_article_id(fingerprint, language)`.
+`editorial_state` tracks only the EN article id as canonical reference.
+
+---
+
+## Editorial quality gate
+
+An LLM editorial reviewer runs **after EN drafting and before image/DE
+generation**. Implemented in `WriterWorkflow._run_quality_gate()`.
+
+The gate scores each draft on five dimensions (each 0.0–1.0):
+**impact**, **specificity**, **readworthiness**, **grounding**,
+**execution**. It returns one of three decisions:
+
+| Decision | Meaning | What happens |
+|---|---|---|
+| `approve` | Grounded, specific, clear reader payoff | Continue to image + DE |
+| `rewrite` | Source has substance, draft wastes it (vague angle, weak headline, buried stakes) | Writer reruns once with a `rewrite_brief` |
+| `dismiss` | Source itself can't support a worthwhile article | Story drops out for this cycle (no EN, no DE, no image) |
+
+After a rewrite, the gate runs again. A second `rewrite` or `dismiss`
+drops the story — we don't loop.
+
+### Fail‑soft on outage
+
+If the gate raises (OpenAI hiccup, timeout, etc.):
+
+- **First attempt** → fall back to **approve** the original draft. Logged
+  at `ERROR` with the prefix `QUALITY_GATE_OUTAGE` for log filtering. The
+  writer prompt's own discipline rules already apply.
+- **Rewrite attempt** → fall back to **dismiss**. We won't publish an
+  unreviewed second draft.
+
+This is a deliberate trade‑off: a sustained gate outage publishes
+unreviewed drafts rather than producing a silent zero‑publish window.
+
+### Prompt precedence on rewrites of `patch` actions
+
+When a "patch" action (updating an existing article) gets rewritten, the
+writer payload contains both `existing_article` and
+`quality_gate_feedback`. The writer prompt explicitly states
+`quality_gate_feedback` wins — don't preserve weak phrasing from the
+existing article just because it was published before.
+
+---
+
+## Editorial memory wiki
+
+A markdown coaching wiki that feeds the EN writer and learns from
+quality‑gate feedback. **Coaching, not facts** — `source_digests` remain
+the only authority for football claims.
+
+### Layout
+
+```
+editorial_memory/
+├── wiki/
+│   ├── what_makes_a_story_readworthy.md   ← seed, hand‑edited
+│   ├── headline_patterns_that_work.md     ← seed, hand‑edited
+│   ├── thin_story_rejection_rules.md      ← seed, hand‑edited
+│   └── rewrite_lessons.md                 ← LLM‑maintained
+└── raw_feedback/
+    └── YYYY-MM-DD.md                      ← append‑only event log
+```
+
+### Read path (every EN draft)
+
+`load_editorial_memory()` concatenates the wiki pages (capped at ~7000
+chars total) and injects them into the writer payload as
+`editorial_memory`. The writer prompt is explicit: this is coaching, not
+facts; `source_digests` win on conflict.
+
+### Write path (after each gate decision)
+
+When the gate returns `rewrite` or `dismiss` (clean first‑attempt
+approves are skipped):
+
+1. The event is appended to `raw_feedback/YYYY-MM-DD.md`.
+2. The **editorial memory agent** reads the existing
+   `wiki/rewrite_lessons.md` plus the new event and rewrites the page in
+   place. Instructed to merge duplicate lessons and keep ~8–14 high‑signal
+   bullets, under 1200 words.
+
+Only `rewrite_lessons.md` is auto‑updated. The other three wiki pages are
+hand‑edited seeds.
+
+### Why memory lives on its own branch
+
+To allow branch protection on `main` and to keep main's history clean,
+the workflow stores memory on a dedicated `editorial-memory` data
+branch:
+
+1. **Cycle start**: fetches `editorial_memory/` from `editorial-memory`
+   and overlays it on the working tree.
+2. **Cycle end**: switches to `editorial-memory` (creating it as an orphan
+   branch on first run), applies the updated `editorial_memory/`, and
+   pushes there — never to main.
+
+`main` holds **code** (including the wiki seed files); `editorial-memory`
+holds **runtime data**. The seeds on main are only used until the data
+branch exists; after that, the data branch is the source of truth.
+
+To inspect live memory:
+```bash
+git fetch
+git checkout origin/editorial-memory -- editorial_memory/
+```
+
+To pause learning, comment out the "Persist editorial memory" step in
+`.github/workflows/editorial-cycle.yml`.
+
+### Comparison to Karpathy's LLM wiki pattern
+
+Same family of idea (LLM‑maintained markdown, append‑only log + curated
+summary), much narrower scope. Karpathy's wiki encodes **knowledge** with
+cross‑references and lint passes; ours encodes editorial **taste** in a
+single curated page. Natural growth path: let the agent update any wiki
+page, add an `index.md`, run a periodic lint cycle.
+
+---
+
+## Image cascade
+
+Four‑tier fallback in `writer/image_selector.py`, evaluated in order per
+article:
+
+| Tier | Source | Notes |
+|---|---|---|
+| 1a | Google CC Search (`GoogleCCSearchClient`) | Skipped when a dominant player is present (headshot preferred) |
+| 1b | Wikimedia Commons (`WikimediaCommonsClient`) | Public MediaWiki API, no key. Query: player name or `team_code + "NFL football"`. `upload.wikimedia.org` requires `User-Agent` on downloads. |
+| 2 | Player headshot from `public.players` | Dominant single‑player stories only. Subject to a 40%‑ceil per‑cycle budget cap. |
+| 3 | Curated pool (`content.curated_images`) | Pre‑generated + manually reviewed PNGs. Scene chosen via `_scene_candidates()` + `_SCENE_RULES` (keyword‑matched, then fingerprint‑deterministic rotation). Uncapped. |
+| 4 | Team logo reference string | Always succeeds; downstream renders team logo. |
+
+Tiers 1–3 produce real image URLs; tier 4 is a Flutter asset reference
+(`asset://team_logo/{TEAM_CODE}`). A `generic_nfl` fallback
+(`asset://generic/nfl`) fires when there's no `team_code`. Gemini AI
+generation was removed in an earlier iteration.
+
+### Image validator
+
+`image_validator.does_image_match` accepts `expected_team_code` +
+`expected_team_name` and **rejects only on positive contradiction**:
+different‑team wordmarks, portraits/mugshots, dated archival photos, low
+quality. Ambiguity = accept. The OCR check (`image_contains_text`)
+accepts jersey/yard‑line numbers but rejects words/wordmarks/scoreboards.
+
+---
+
+## Supabase
+
+Two schemas, two auth patterns:
+
+| Table | Schema | Auth | Adapter |
+|---|---|---|---|
+| `editorial_state` | `public` | Service role key (PostgREST) | `EditorialStateStore` |
+| `team_article` | `content` | Service role key + `Content-Profile: content` | `ArticleWriter` |
+| Edge fns (feed, lookup) | n/a | Anon key (`SUPABASE_FUNCTION_AUTH_TOKEN`) | `RawFeedReader`, `ArticleLookupAdapter` |
+
+> **PostgREST routing note**: `team_article` is no longer exposed under
+> the `content` schema via direct queries. Read scripts hit
+> `/rest/v1/team_article` with **no** `Accept-Profile` header (public
+> schema routing). `ArticleWriter` (the write path) still uses the
+> `content` profile header for INSERT/PATCH via the Supabase client.
+> Don't add a profile header to read‑only PostgREST calls or you'll get a
+> 406.
+
+`SUPABASE_FUNCTION_AUTH_TOKEN` is optional — falls back to
+`SUPABASE_SERVICE_ROLE_KEY` via
+`Settings.resolved_function_auth_token()`. Edge functions typically need
+the anon key (JWT with `role=anon`), not the service role key.
+
+### Migrations
+
+All migrations applied **manually via Supabase SQL Editor** (not
+`supabase db push`):
+
+- `001_editorial_state.sql` — applied
+- `002_add_source_urls.sql` — applied
+- `003_add_author.sql` — applied
+- `004_add_mentioned_players.sql` — applied
+- `005_curated_images.sql` — applied (`content.curated_images` + storage GRANTs)
+- `006_add_sources.sql` — applied (`sources jsonb` on `content.team_article`)
+- `007_add_story_fingerprint.sql` — **pending** (`story_fingerprint text` on `content.team_article`)
+
+---
+
+## Frontend edge functions
+
+Two Deno edge functions in `supabase/functions/` expose
+`content.team_article` to the Flutter frontend. Both require
+`verify_jwt = true` — callers must pass a Supabase anon JWT as
+`Authorization: Bearer <token>`.
+
+| Function | Method | Purpose |
+|---|---|---|
+| `get-articles` | POST | Cursor‑paginated list. Body: `{ language?, limit?, cursor? }`. Returns `{ items, next_cursor }`. Cursor on `(created_at DESC, id DESC)`. List columns only. |
+| `get-article-detail` | POST | Full article + enriched players. Body: `{ id }`. Replaces raw `mentioned_players` ID array with `{ player_id, display_name, headshot }` via `public.players` join. |
+
+Shared helpers in `supabase/functions/_shared/`:
+
+- `cors.ts` — CORS headers, `jsonResponse()`, `preflight()` (OPTIONS).
+- `supabase.ts` — `clientFromRequest(req)` factory: reads `SUPABASE_URL`
+  + `SUPABASE_ANON_KEY` from env, forwards caller's `Authorization`,
+  `persistSession: false`.
+
+> **RLS note**: `content.team_article` currently has no SELECT grant for
+> the `anon` role. Both functions return 200 with empty results until
+> `GRANT SELECT ON content.team_article TO anon;` (or an equivalent RLS
+> policy) is applied.
+
+---
+
+## Configuration
+
+`app/config.py` uses `pydantic-settings` with a `.env` file. Per‑agent
+model IDs are configurable via env vars:
+
+| Env var | Default | Agent |
+|---|---|---|
+| `OPENAI_MODEL_ARTICLE_DATA_AGENT` | `gpt-5.4-mini` | Article digest |
+| `OPENAI_MODEL_STORY_CLUSTER_AGENT` | `gpt-5.4` | Cluster synthesis |
+| `OPENAI_MODEL_EDITORIAL_ORCHESTRATOR_AGENT` | `gpt-5.4` | Top‑N selection |
+| `OPENAI_MODEL_ARTICLE_WRITER_AGENT` | `gpt-5.4-mini` | EN + DE drafting |
+| `OPENAI_MODEL_PERSONA_SELECTOR_AGENT` | `gpt-5.4-mini` | Persona pick |
+| `OPENAI_MODEL_ARTICLE_QUALITY_GATE_AGENT` | `gpt-5.4-mini` | Quality gate |
+| `OPENAI_MODEL_EDITORIAL_MEMORY_AGENT` | `gpt-5.4-mini` | Memory revision |
+| `OPENAI_MODEL_VISION_VALIDATOR` | (provider default) | Image contradiction check |
+
+`agent_model(name)` resolves an agent name to its model string.
+`editorial_memory_dir` defaults to `Path("editorial_memory")` (relative).
+
+> **Tests must use** `Settings(_env_file=None)` and explicitly
+> `monkeypatch.delenv` model override vars to avoid real `.env` bleeding
+> into fixtures.
+
+---
+
+## Prompts
+
+All prompt text lives in YAML (`app/editorial/prompts.yml`,
+`app/writer/prompts.yml`), loaded once via `@lru_cache`. Each module
+validates required prompt keys at load time. Prompt iteration does not
+require Python changes.
+
+Notable prompt blocks worth knowing:
+
+- **Beat‑reporter texture** (writer EN + DE): cap ~15% of prose.
+  Active/specific verbs, scene/stakes language tied to source facts,
+  varied sentence length, concrete nouns. Texture rides on facts, never
+  replaces them.
+- **Source‑as‑story anti‑pattern** (writer EN + DE): the publication of
+  a source article is never the story. For roundups/rankings/grades the
+  writer must focus on *this* team's row, and is forbidden from sentences
+  whose subject is the source publication or the act of publishing. A
+  per‑paragraph self‑check: "what new football fact did this give the
+  reader?"
+- **Roundup / ranking / grade extraction rule** (article data agent):
+  for multi‑team source pieces, extract row‑level verdicts as
+  `key_facts`, not column‑level meta. Column‑level only →
+  `content_status="thin"` + `confidence <= 0.3`, routing to the writer's
+  "thin → write shorter" path.
+- **Reader contract / angle discipline / specificity checks** (writer):
+  added in PR #22 to push drafts toward concrete reader payoff over
+  generic team chatter.
+- **Editorial taste test / single‑source scoring guide** (orchestrator):
+  added in PR #22 to suppress vague single‑source items unless their
+  title carries concrete news.
+
+---
+
+## CI / GitHub Actions
+
+`.github/workflows/editorial-cycle.yml`:
+
+- **Schedule**: `0 */2 * * *` (every 2 hours).
+- **Manual**: `workflow_dispatch` with `top_n` / `lookback_hours`
+  overrides.
+- **Concurrency**: group `editorial-cycle`, `cancel-in-progress: false` —
+  no overlapping runs.
+- **Timeout**: 30 minutes.
+- **Steps**:
+  1. Checkout main.
+  2. Sync `editorial_memory/` from the `editorial-memory` data branch
+     (creates‑on‑first‑run via the persist step).
+  3. Install + run cycle.
+  4. Persist memory: snapshot `editorial_memory/`, switch to the
+     `editorial-memory` branch (orphan if missing), apply snapshot, push.
+  5. Upload `var/output.json` as an artifact (14d retention).
+
+Required secrets: `OPENAI_API_KEY`, `SUPABASE_URL`,
+`SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_NEWS_FEED_URL`,
+`SUPABASE_ARTICLE_LOOKUP_URL`, `SUPABASE_FUNCTION_AUTH_TOKEN`,
+`EXTRACTION_FUNCTION_AUTH_TOKEN`. Optional: `IMAGE_SELECTION_URL`,
+`GOOGLE_CUSTOM_SEARCH_KEY`, `GOOGLE_CUSTOM_SEARCH_ENGINE_ID`. Model
+overrides via repo vars (`OPENAI_MODEL_*`).
+
+`EXTRACTION_FUNCTION_AUTH_TOKEN` authenticates calls to the
+knowledge‑extraction Cloud Run functions (`AsyncJobClient` sends it as
+`Authorization: Bearer <token>`). The ingestion worker fails fast at
+startup if this secret is unset. Rotation procedure:
+[`docs/rotating-extraction-function-auth-token.md`](./docs/rotating-extraction-function-auth-token.md).
+
+---
+
+## Reports & tooling
+
+### Cycle report (`scripts/build_cycle_report.py`)
+
+Reads `var/output.json` + fetches matching `content.team_article` rows by
+fingerprint. Writes `var/cycle_report.html` and prints a `file://` URL.
+Per‑story card:
+
+- **Left**: rank, score, action, reasoning, team codes, player mentions,
+  source digests.
+- **Right**: EN + DE articles with cover image, tier badge, language
+  badge, full content, collapsible extras (bullets, X post, mentioned
+  players with headshots).
+- **Header KPIs**: stories / written / updated / prevented, language
+  split, image tier mix.
+
+### Overview report (`scripts/build_overview_report.py`)
+
+All `team_article` rows paired EN/DE, with trace + state. Writes
+`var/overview_report.html`. Optional `--limit N`.
+
+### Architecture graph (`scripts/build_architecture_graph.py`)
+
+Generates a manual architecture YAML/graph snapshot in `scripts/`. See
+the script for usage.
+
+---
+
+## Testing
+
+```bash
+# All tests (191+ at last count)
+./venv/bin/pytest tests/ -v
+
+# Single test class or test
+./venv/bin/pytest tests/test_helpers.py::TestGroupByEntity
+./venv/bin/pytest tests/test_helpers.py::TestGroupByEntity::test_player_entity_clusters_across_teams
+```
+
+Test conventions:
+
+- `Settings(_env_file=None)` to avoid `.env` bleed.
+- Explicit `monkeypatch.delenv` for any `OPENAI_MODEL_*` override that
+  could affect the test.
+- Async tests use `pytest-asyncio` in auto mode (set in
+  `pyproject.toml`).
+
+Suites worth knowing:
+
+- `test_article_quality_gate.py` — approve / dismiss / rewrite‑then‑approve
+  / rewrite‑then‑dismiss / fail‑soft / fail‑closed‑on‑rewrite.
+- `test_editorial_memory.py` — wiki read path, raw feedback append, memory
+  injection into writer payload, memory agent revision.
+- `test_helpers.py` — entity clustering edge cases.
+- `test_schemas.py` — Pydantic model `extra="forbid"` and bounds.
+
+---
+
+## Pointers for future work
+
+| Area | File |
+|---|---|
+| Add a wiki page the memory agent can update | `app/writer/editorial_memory.py`, `app/writer/prompts.yml` |
+| Tune the quality‑gate scoring rubric | `app/writer/prompts.yml` (`article_quality_gate_agent`) |
+| Add a new image source tier | `app/writer/image_selector.py`, `app/writer/image_clients.py` |
+| Add a new agent | `app/writer/agents.py` or `app/editorial/` + register in `Settings.agent_models` |
+| Change cycle cadence | `.github/workflows/editorial-cycle.yml` (`schedule.cron`) and `LOOKBACK_HOURS` |

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from pathlib import Path
 
 from pydantic import AnyHttpUrl, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -46,6 +47,9 @@ class Settings(BaseSettings):
     openai_model_editorial_orchestrator_agent: str = "gpt-5.4"
     openai_model_article_writer_agent: str = "gpt-5.4-mini"
     openai_model_persona_selector_agent: str = "gpt-5.4-mini"
+    openai_model_article_quality_gate_agent: str = "gpt-5.4-mini"
+    openai_model_editorial_memory_agent: str = "gpt-5.4-mini"
+    editorial_memory_dir: Path = Path("editorial_memory")
 
     openai_temperature: float | None = None
     openai_max_tokens: int | None = None
@@ -66,6 +70,8 @@ class Settings(BaseSettings):
             "editorial_orchestrator_agent": self.openai_model_editorial_orchestrator_agent,
             "article_writer_agent": self.openai_model_article_writer_agent,
             "persona_selector_agent": self.openai_model_persona_selector_agent,
+            "article_quality_gate_agent": self.openai_model_article_quality_gate_agent,
+            "editorial_memory_agent": self.openai_model_editorial_memory_agent,
         }
 
     def agent_model(self, agent_name: str) -> str:

--- a/app/editorial/prompts.yml
+++ b/app/editorial/prompts.yml
@@ -7,6 +7,20 @@ article_data_agent: |
   Closed-world rule: use ONLY facts that appear in the provided input fields
   and in the tool output. Never add outside knowledge.
 
+  Reader-payoff extraction:
+  Your digest feeds the writer. Do not stop at "what happened"; extract why a
+  fan would care enough to tap the story today. Find the strongest concrete
+  angle the source supports:
+  - immediate impact: roster spot, injury status, role, starter/backup battle,
+    contract/cap consequence, draft pick, suspension, playoff/standings stakes
+  - named people: players, coaches, executives, opponents, exact teams
+  - tension/change: what changed, who benefits, who loses leverage, what decision
+    now sits in front of the team
+  - specificity: dates, numbers, grades, ranks, pick numbers, contract figures,
+    quotes, status labels
+  Put the strongest reader-payoff fact near the top of key_facts. Avoid vague
+  facts like "the team faces questions" unless the source names the question.
+
   If the article is not found, return confidence=0.1 and content_status="missing".
   If the article has very little useful content, return content_status="thin".
 
@@ -28,7 +42,9 @@ article_data_agent: |
 
   Output field instructions:
   - summary: 2-4 sentence summary of the main news. For roundups, this is the
-    teams' actual verdicts/picks/grades, not the column's framework.
+    teams' actual verdicts/picks/grades, not the column's framework. The first
+    sentence should name the central team/player and the concrete development.
+    The final sentence should state the reader payoff when the source supports it.
   - key_facts: 1-8 key facts, each under 30 words, ordered by importance.
     For roundups, each fact should be a team-specific verdict, named pick,
     grade, or quoted reason. Never make "X published a column about Y" a fact.
@@ -50,9 +66,38 @@ story_cluster_agent: |
   Closed-world rule: use ONLY facts from the supplied articles and tool results.
   Never add outside NFL knowledge.
 
+  Editorial angle rule:
+  Synthesize toward the most readable story, not the broadest summary. The best
+  cluster result should answer:
+  - What exactly changed?
+  - Which team/player is most central?
+  - Why does it matter now?
+  - What concrete next consequence is supported by the digests?
+
+  Specificity ladder:
+  1. Named player/coach/team + action + consequence
+  2. Named player/coach/team + action
+  3. Team-level development with a specific number/rank/quote/status
+  4. Generic league/team chatter
+  Favor level 1 or 2 whenever the digests allow it. Do not let level 4 language
+  drive the headline or synthesis.
+
+  News value scoring rubric:
+  - 0.85-1.00: breaking or materially consequential news with named people and
+    immediate roster, injury, legal, contract, coaching, standings, or draft impact
+  - 0.70-0.84: strong team-specific analysis with concrete stakes, numbers, or
+    a credible next-step consequence
+  - 0.45-0.69: useful but incremental story, soft quote, routine ranking, or
+    limited detail
+  - 0.00-0.44: vague, source-meta, recycled, or low-substance item
+
   Output field instructions:
-  - cluster_headline: concise headline summarizing the cluster (under 100 chars)
-  - synthesis: 2-4 sentence synthesis combining all source perspectives
+  - cluster_headline: concise, specific headline under 100 chars. Include a
+    proper noun, action verb, and concrete consequence when available. Avoid
+    generic labels like "NFL update", "team news", "draft buzz", or "analysis".
+  - synthesis: 2-4 sentence synthesis combining all source perspectives. Start
+    with the concrete development, then explain the reader payoff/stakes. Do not
+    summarize the existence of coverage.
   - news_value_score: 0.0-1.0 — how newsworthy this cluster is right now
   - is_new: true if fingerprint not in published_fingerprints, false otherwise
   - story_fingerprint: a short descriptive slug for this story (e.g. "bills-trade-star-wr"). The system replaces this with a deterministic hash — your value is used only for logging.
@@ -93,6 +138,21 @@ editorial_orchestrator_agent: |
   After processing all clusters and evaluating single-source articles, rank ALL
   candidates together by news_value_score.
 
+  Editorial taste test:
+  Select stories that make a fan want to open T4L today. A story earns a high
+  rank only when it has a clear reader promise: named people, concrete change,
+  consequence, conflict, decision point, or team-specific stakes. Penalize vague
+  items whose appeal is only that a publication wrote about a team.
+
+  Single-source scoring guide:
+  - Do not penalize true breaking news for having one source.
+  - Do penalize vague single-source headlines with no named player, team-specific
+    consequence, number, quote, status, or transaction.
+  - Assign 0.70+ only when the headline/title itself contains concrete news or a
+    specific fan-relevant angle.
+  - Keep generic rumors, evergreen rankings, and low-substance opinion pieces
+    below 0.60 unless the title includes a concrete team/player verdict.
+
   Select the top {top_n} stories. For each, compare against published_stories:
   - Set action="publish" if the story is genuinely new (no matching fingerprint AND
     no significant headline overlap with published_stories)
@@ -113,5 +173,6 @@ editorial_orchestrator_agent: |
   Output field instructions:
   - stories: ranked list of StoryEntry objects to publish or update
   - skipped_stories: list of StoryEntry objects that were skipped
-  - reasoning: 2-3 sentence summary of your editorial judgment this cycle
+  - reasoning: 2-3 sentence summary of your editorial judgment this cycle,
+    explaining the strongest reader-payoff themes, not just source volume
   - prevented_duplicates: count of stories skipped due to fingerprint match

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -146,6 +146,24 @@ class PersonaSelection(BaseModel):
     reasoning: str
 
 
+class ArticleQualityDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    decision: Literal["approve", "rewrite", "dismiss"]
+    impact_score: float = Field(ge=0.0, le=1.0)
+    specificity_score: float = Field(ge=0.0, le=1.0)
+    readworthiness_score: float = Field(ge=0.0, le=1.0)
+    grounding_score: float = Field(ge=0.0, le=1.0)
+    execution_score: float = Field(ge=0.0, le=1.0)
+    reasoning: str
+    rewrite_brief: str | None = None
+
+
+class EditorialMemoryRevision(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    updated_markdown: str
+    change_summary: str
+
+
 # --- Editorial state (cross-cycle memory) ---
 
 

--- a/app/writer/agents.py
+++ b/app/writer/agents.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from agents import Agent
 
 from app.config import Settings
-from app.schemas import PublishableArticle
+from app.schemas import ArticleQualityDecision, EditorialMemoryRevision, PublishableArticle
 from app.writer.model import build_model_settings
 from app.writer.prompts import get_prompt
 
@@ -30,4 +30,26 @@ def build_article_writer_agent_de(settings: Settings) -> Agent:
         model_settings=build_model_settings(settings, parallel_tool_calls=False),
         tools=[],
         output_type=PublishableArticle,
+    )
+
+
+def build_article_quality_gate_agent(settings: Settings) -> Agent:
+    return Agent(
+        name="Article Quality Gate Agent",
+        instructions=get_prompt("article_quality_gate_agent"),
+        model=settings.agent_model("article_quality_gate_agent"),
+        model_settings=build_model_settings(settings, parallel_tool_calls=False),
+        tools=[],
+        output_type=ArticleQualityDecision,
+    )
+
+
+def build_editorial_memory_agent(settings: Settings) -> Agent:
+    return Agent(
+        name="Editorial Memory Agent",
+        instructions=get_prompt("editorial_memory_agent"),
+        model=settings.agent_model("editorial_memory_agent"),
+        model_settings=build_model_settings(settings, parallel_tool_calls=False),
+        tools=[],
+        output_type=EditorialMemoryRevision,
     )

--- a/app/writer/editorial_memory.py
+++ b/app/writer/editorial_memory.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from app.schemas import ArticleQualityDecision, PublishableArticle, StoryEntry
+from app.writer.personas import Persona
+
+WIKI_DIRNAME = "wiki"
+RAW_FEEDBACK_DIRNAME = "raw_feedback"
+REWRITE_LESSONS_FILE = "rewrite_lessons.md"
+MAX_MEMORY_CHARS = 7000
+MAX_WIKI_PAGE_CHARS = 2400
+
+
+def _read_markdown(path: Path, *, max_chars: int = MAX_WIKI_PAGE_CHARS) -> str:
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return ""
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars].rstrip() + "\n\n[truncated]"
+
+
+def load_editorial_memory(memory_dir: Path, story: StoryEntry) -> str:
+    """Return compact markdown coaching notes for the EN writer.
+
+    This intentionally reads a maintained wiki, not raw event logs. The content
+    is advisory context; the writer prompt keeps source_digests as the factual
+    authority.
+    """
+    wiki_dir = memory_dir / WIKI_DIRNAME
+    if not wiki_dir.exists():
+        return ""
+
+    pages: list[tuple[str, str]] = []
+    preferred = [
+        "what_makes_a_story_readworthy.md",
+        "headline_patterns_that_work.md",
+        "thin_story_rejection_rules.md",
+        REWRITE_LESSONS_FILE,
+    ]
+    seen: set[Path] = set()
+    for name in preferred:
+        path = wiki_dir / name
+        if path.exists():
+            pages.append((name, _read_markdown(path)))
+            seen.add(path)
+    for path in sorted(wiki_dir.glob("*.md")):
+        if path not in seen:
+            pages.append((path.name, _read_markdown(path)))
+
+    heading = (
+        "Editorial memory for this EN draft. Treat as coaching, not facts.\n"
+        f"Story: {story.cluster_headline}\n"
+        f"Teams: {', '.join(story.team_codes) or 'unknown'}\n"
+    )
+    sections = [heading]
+    for name, text in pages:
+        if not text:
+            continue
+        sections.append(f"\n--- {name} ---\n{text}")
+
+    memory = "\n".join(sections).strip()
+    if len(memory) <= MAX_MEMORY_CHARS:
+        return memory
+    return memory[:MAX_MEMORY_CHARS].rstrip() + "\n\n[editorial memory truncated]"
+
+
+def build_feedback_event_markdown(
+    *,
+    cycle_id: str,
+    story: StoryEntry,
+    article: PublishableArticle,
+    persona: Persona,
+    decision: ArticleQualityDecision,
+    rewrite_attempt: int,
+) -> str:
+    timestamp = datetime.now(UTC).isoformat()
+    brief = decision.rewrite_brief or ""
+    return (
+        f"## {timestamp} | {decision.decision.upper()} | attempt {rewrite_attempt}\n\n"
+        f"- cycle_id: `{cycle_id}`\n"
+        f"- fingerprint: `{story.story_fingerprint}`\n"
+        f"- story: {story.cluster_headline}\n"
+        f"- headline: {article.headline}\n"
+        f"- persona: {persona.byline} ({persona.id})\n"
+        f"- scores: impact={decision.impact_score:.2f}, "
+        f"specificity={decision.specificity_score:.2f}, "
+        f"readworthiness={decision.readworthiness_score:.2f}, "
+        f"grounding={decision.grounding_score:.2f}, "
+        f"execution={decision.execution_score:.2f}\n"
+        f"- reasoning: {decision.reasoning}\n"
+        f"- rewrite_brief: {brief or 'n/a'}\n\n"
+    )
+
+
+def append_raw_feedback(memory_dir: Path, event_markdown: str) -> Path:
+    raw_dir = memory_dir / RAW_FEEDBACK_DIRNAME
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    path = raw_dir / f"{datetime.now(UTC).date().isoformat()}.md"
+    if not path.exists():
+        path.write_text("# Editorial Feedback Events\n\n", encoding="utf-8")
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(event_markdown)
+    return path
+
+
+def read_rewrite_lessons(memory_dir: Path) -> str:
+    return _read_markdown(
+        memory_dir / WIKI_DIRNAME / REWRITE_LESSONS_FILE,
+        max_chars=8000,
+    )
+
+
+def write_rewrite_lessons(memory_dir: Path, markdown: str) -> Path:
+    wiki_dir = memory_dir / WIKI_DIRNAME
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    path = wiki_dir / REWRITE_LESSONS_FILE
+    path.write_text(markdown.strip() + "\n", encoding="utf-8")
+    return path
+
+
+def build_memory_revision_payload(
+    *,
+    existing_markdown: str,
+    feedback_event_markdown: str,
+) -> dict[str, str]:
+    return {
+        "target_page": f"{WIKI_DIRNAME}/{REWRITE_LESSONS_FILE}",
+        "existing_markdown": existing_markdown,
+        "new_feedback_event": feedback_event_markdown,
+    }

--- a/app/writer/prompts.py
+++ b/app/writer/prompts.py
@@ -9,6 +9,8 @@ PROMPTS_PATH = Path(__file__).with_name("prompts.yml")
 REQUIRED_PROMPTS = {
     "article_writer_agent",
     "article_writer_agent_de",
+    "article_quality_gate_agent",
+    "editorial_memory_agent",
     "persona_selector_agent",
 }
 

--- a/app/writer/prompts.yml
+++ b/app/writer/prompts.yml
@@ -17,6 +17,41 @@ article_writer_agent: |
   Closed-world rule: use ONLY facts from the supplied source_digests.
   Never add outside NFL knowledge unless the source explicitly states it.
 
+  Editorial memory:
+  The input may contain `editorial_memory`, a compact markdown wiki of prior
+  quality-control lessons. Use it as coaching about T4L taste: what made past
+  articles stronger, what got rewritten, and what got dismissed. It is NOT a
+  source of football facts. If editorial_memory conflicts with source_digests,
+  source_digests win. Do not mention the memory or past feedback in the article.
+
+  Reader contract:
+  Write the article a fan would open during a quick news check. The piece must
+  have a clear promise in the first screen: a named team/player, a concrete
+  development, and the consequence or tension that makes it worth reading now.
+  Specific beats broad. "Chiefs face a tougher Rashee Rice decision after..."
+  beats "Chiefs receive update on offseason situation."
+
+  Angle discipline:
+  Before drafting, choose ONE supported angle from the digests:
+  - consequence: what this changes for roster, role, cap, draft, injury timeline,
+    coaching plan, legal/disciplinary process, or next game
+  - conflict: competing pressures, decision point, leverage shift, risk/reward
+  - reveal: a new quote, number, grade, rank, status, or named evaluation that
+    changes how the story reads
+  Build the headline, sub_headline, introduction, and first two paragraphs around
+  that angle. Do not write a generic "team continues to monitor situation" story
+  unless the digests provide no sharper fact.
+
+  Specificity checks:
+  - Headline should usually contain a proper noun plus an action verb or concrete
+    status. Avoid "news", "update", "situation", "questions", "buzz", "noise",
+    "intrigue", and "storyline" unless paired with the exact fact.
+  - The first sentence must state the strongest fact, not introduce the topic.
+  - The second or third sentence must give the reader payoff: why this matters
+    now for this team/player.
+  - Every paragraph needs at least one concrete fact, named person/team, number,
+    quote, status, or direct consequence from source_digests.
+
   Source-as-story anti-pattern (do not violate):
   - The publication of a source article is NEVER the story. The story is the
     underlying event, fact, ranking, grade, pick, or quote that lives INSIDE the
@@ -72,12 +107,23 @@ article_writer_agent: |
   Output field instructions:
   - team: the primary NFL team code. MUST be exactly one of these 32 abbreviations: ARI, ATL, BAL, BUF, CAR, CHI, CIN, CLE, DAL, DEN, DET, GB, HOU, IND, JAX, KC, LAC, LAR, LV, MIA, MIN, NE, NO, NYG, NYJ, PHI, PIT, SEA, SF, TB, TEN, WAS. Pick from team_codes in the input when possible — it has already been normalized to this whitelist. NEVER use "NFL", "League", nicknames ("Chargers"), or college codes. If team_codes is empty, pick the abbreviation for the team most central to the story from the source_digests.
   - language: always "en-US"
-  - headline: a compelling, specific headline under 100 characters
-  - sub_headline: a secondary headline that adds context, under 150 characters
-  - introduction: 2-3 sentence hook that draws the reader in. Concise, punchy.
-  - content: the full article body. 300-600 words (go shorter when sources are thin — do not pad). Use facts from source_digests only. Paragraphs separated by double newlines. Write each sentence as a direct statement; no meta-commentary about source quality.
-  - x_post: a tweet-length (under 280 chars) summary suitable for X/Twitter
-  - bullet_points: 3-5 bullet points summarizing key takeaways, one per line
+  - headline: a compelling, specific headline under 100 characters. Name the
+    central team/player and the concrete development or consequence. No vague
+    headline filler.
+  - sub_headline: a secondary headline under 150 characters that adds the
+    reader payoff, number, quote, status, or next consequence. Do not repeat the
+    headline in softer words.
+  - introduction: 2-3 sentence hook. Sentence 1 states the strongest concrete
+    fact. Sentence 2 or 3 explains why it matters now. Concise, punchy.
+  - content: the full article body. 300-600 words (go shorter when sources are
+    thin — do not pad). Use facts from source_digests only. Paragraphs separated
+    by double newlines. Write each sentence as a direct statement; no
+    meta-commentary about source quality. Put the nut graf in paragraph 2:
+    the clearest consequence, tension, or decision point supported by the facts.
+  - x_post: a tweet-length (under 280 chars) summary suitable for X/Twitter.
+    It should carry the same concrete angle as the headline, not a generic recap.
+  - bullet_points: 3-5 bullet points summarizing key takeaways, one per line.
+    Each bullet must contain a concrete fact or consequence; no filler bullets.
   - story_fingerprint: copy the story_fingerprint from the input VERBATIM — do not modify it
   - author: copy the persona's byline from the input VERBATIM (e.g. "Marcus Reed")
   - mentioned_players: leave as empty list []. The system populates this deterministically from the feed's player entities after you return; do not attempt to emit player IDs yourself.
@@ -95,6 +141,14 @@ article_writer_agent: |
 
   When action="publish":
   - Write a fresh article as normal. Ignore any existing_article field if present.
+
+  When the input contains `quality_gate_feedback`:
+  - This is a rewrite request for a draft that failed editorial review.
+  - Use `previous_draft` only to understand what to improve; do not preserve weak
+    phrasing, vague angles, filler paragraphs, or buried stakes.
+  - Follow the rewrite_brief exactly where it is supported by source_digests.
+  - Keep the same story_fingerprint, language, team discipline, and author rules.
+  - Do not mention the quality gate, review process, or that this is a rewrite.
 
 article_writer_agent_de: |
   Du bist NFL-Artikelautor für T4L (Tackle4Loss) und schreibst für deutschsprachige
@@ -125,6 +179,36 @@ article_writer_agent_de: |
 
   Closed-world-Regel: Nutze AUSSCHLIESSLICH Fakten aus den gelieferten
   source_digests. Kein externes NFL-Wissen, außer die Quelle sagt es explizit.
+
+  Leserinnen-Vertrag:
+  Schreibe den Artikel so, dass ein Fan ihn beim schnellen News-Check öffnen
+  will. Schon im ersten Screen braucht das Stück ein klares Versprechen: ein
+  genanntes Team/ein genannter Spieler, eine konkrete Entwicklung und die
+  Konsequenz oder Spannung, die sie jetzt lesenswert macht. Spezifisch schlägt
+  breit. „Chiefs stehen nach ... vor schwererer Rashee-Rice-Entscheidung“
+  schlägt „Chiefs erhalten Update zu Offseason-Thema“.
+
+  Winkel-Disziplin:
+  Wähle vor dem Schreiben EINEN belegten Winkel aus den Digests:
+  - Konsequenz: was sich für Kader, Rolle, Cap, Draft, Verletzungsplan,
+    Coaching-Plan, juristischen/disziplinarischen Prozess oder nächstes Spiel ändert
+  - Konflikt: konkurrierende Zwänge, Entscheidungspunkt, verschobene Hebel,
+    Risiko/Ertrag
+  - Enthüllung: neues Zitat, Zahl, Note, Rang, Status oder konkrete Bewertung,
+    die die Story schärfer macht
+  Baue Headline, Subheadline, Einstieg und die ersten zwei Absätze um diesen
+  Winkel. Keine generische „Team beobachtet Situation weiter“-Story, wenn die
+  Digests einen schärferen Fakt liefern.
+
+  Spezifitäts-Check:
+  - Die Headline enthält normalerweise einen Eigennamen plus aktives Verb oder
+    konkreten Status. Meide „News“, „Update“, „Situation“, „Fragen“, „Gerüchte“,
+    „Thema“, „Storyline“, außer der exakte Fakt steht direkt daneben.
+  - Der erste Satz nennt den stärksten Fakt, statt nur das Thema einzuführen.
+  - Satz zwei oder drei liefert den Leserinnen-Nutzen: warum das jetzt für dieses
+    Team/diesen Spieler zählt.
+  - Jeder Absatz braucht mindestens einen konkreten Fakt, Namen, eine Zahl, ein
+    Zitat, einen Status oder eine direkte Konsequenz aus source_digests.
 
   Anti-Pattern „Quelle als Story" (nicht verletzen):
   - Das Erscheinen eines Quellartikels ist NIEMALS die Story. Die Story ist das
@@ -191,15 +275,26 @@ article_writer_agent_de: |
     Nicknames („Chargers“) oder College-Codes. Wenn team_codes leer ist, wähle
     die Abkürzung des Teams, das im source_digests am zentralsten ist.
   - language: immer "de-DE"
-  - headline: markante, spezifische Schlagzeile unter 100 Zeichen.
-  - sub_headline: ergänzende Schlagzeile mit Kontext, unter 150 Zeichen.
-  - introduction: 2–3 Sätze, die hineinziehen. Prägnant, zupackend.
+  - headline: markante, spezifische Schlagzeile unter 100 Zeichen. Nenne das
+    zentrale Team/den Spieler und die konkrete Entwicklung oder Konsequenz.
+    Keine vage Headline-Füllung.
+  - sub_headline: ergänzende Schlagzeile unter 150 Zeichen, die Nutzwert, Zahl,
+    Zitat, Status oder nächste Konsequenz ergänzt. Nicht die Headline weich
+    wiederholen.
+  - introduction: 2–3 Sätze, die hineinziehen. Satz 1 nennt den stärksten
+    konkreten Fakt. Satz 2 oder 3 erklärt, warum er jetzt zählt. Prägnant,
+    zupackend.
   - content: vollständiger Artikeltext. 300–600 Wörter (bei dünner Quelle kürzer
     – nicht strecken). Absätze durch doppelte Zeilenumbrüche getrennt. Jeder
-    Satz eine direkte Aussage, keine Meta-Kommentare zur Quellenlage.
+    Satz eine direkte Aussage, keine Meta-Kommentare zur Quellenlage. Der zweite
+    Absatz ist der Nut-Graf: die klarste Konsequenz, Spannung oder Entscheidung,
+    die die Fakten tragen.
   - x_post: eine Tweet-lange Zusammenfassung (unter 280 Zeichen) für X/Twitter.
+    Sie trägt denselben konkreten Winkel wie die Headline, keine generische
+    Zusammenfassung.
   - bullet_points: 3–5 Stichpunkte mit den wichtigsten Takeaways, je einer pro
-    Zeile.
+    Zeile. Jeder Bullet enthält einen konkreten Fakt oder eine Konsequenz, keine
+    Füllpunkte.
   - story_fingerprint: kopiere den story_fingerprint aus der Eingabe WORTWÖRTLICH.
   - author: kopiere die byline der Persona WORTWÖRTLICH (z. B. „Marc Richter“).
   - mentioned_players: leere Liste []. Das System befüllt dieses Feld
@@ -258,3 +353,94 @@ persona_selector_agent: |
   - persona_id: exactly one of "analyst", "insider", "columnist"
   - reasoning: one sentence explaining why this persona fits
 
+article_quality_gate_agent: |
+  You are the final editorial quality gate for T4L (Tackle4Loss).
+  You review one already-written NFL article against the original story data.
+  Your job is to decide whether T4L should publish it, rewrite it once, or
+  dismiss the story entirely.
+
+  This is an LLM editorial judgment gate. Do not use rigid keyword rules. A
+  colorful headline or unusual sentence can be approved if it is grounded,
+  specific, and worth reading.
+
+  Inputs:
+  - story: cluster_headline, action, news_value_score, team_codes, player_mentions
+  - source_digests: the only facts the article may use
+  - article: the generated PublishableArticle
+  - persona: the intended byline and voice
+  - rewrite_attempt: 0 for first review, 1 after one rewrite
+
+  Closed-world rule:
+  Judge the article only against source_digests. Do not require outside context.
+  Do not ask for drama, color, or consequences that the digests do not support.
+
+  Editorial standard:
+  T4L should publish daily news that gives a fan a concrete reason to tap:
+  a named team/player, a real development, a decision point, a consequence, a
+  status change, a quote/rank/grade with bite, or a clear team-specific stake.
+  Small stories can pass if they are specific and useful. Big-sounding but vague
+  stories should fail.
+
+  Score each dimension from 0.0 to 1.0:
+  - impact_score: how much the source-supported facts matter to a team/player/fan
+  - specificity_score: names, numbers, statuses, quotes, concrete consequences
+  - readworthiness_score: whether the headline/intro create a real reason to tap
+  - grounding_score: whether claims stay inside source_digests
+  - execution_score: headline, subheadline, intro, nut graf, paragraph substance
+
+  Decision policy:
+  - approve: the article is grounded, specific, and has a clear reader payoff.
+  - rewrite: the source material has enough substance, but the article wastes it
+    through a vague angle, weak headline, buried stakes, generic prose, source-meta
+    framing, or missing consequence.
+  - dismiss: the source material itself is not strong enough for a worthwhile T4L
+    article without inventing stakes, or the rewritten article still fails after
+    rewrite_attempt=1.
+
+  Rewrite vs dismiss:
+  Choose rewrite when you can point to concrete facts already in source_digests
+  that would make a better version. Choose dismiss when the issue is not prose
+  but lack of publishable substance.
+
+  Persona tolerance:
+  Respect the assigned persona. Do not reject a valid analyst, insider, or
+  columnist voice just because it is stylistically different. Reject style only
+  when it obscures facts, adds unsupported claims, or makes the piece less useful.
+
+  Output field instructions:
+  - decision: exactly "approve", "rewrite", or "dismiss"
+  - impact_score, specificity_score, readworthiness_score, grounding_score,
+    execution_score: each 0.0-1.0
+  - reasoning: concise editorial rationale for the decision
+  - rewrite_brief: required when decision="rewrite"; null otherwise. Make it a
+    direct, actionable brief for the writer: name the stronger angle, what to put
+    in the headline/intro, and what to remove. Do not include unsupported facts.
+
+editorial_memory_agent: |
+  You maintain T4L's markdown Editorial Style Wiki.
+  Your job is to compile raw quality-gate feedback into durable coaching notes
+  for future EN article drafts.
+
+  You receive:
+  - target_page: the markdown page you are updating
+  - existing_markdown: the current page contents
+  - new_feedback_event: one quality-gate event with story, headline, scores,
+    reasoning, and rewrite_brief
+
+  Maintain the wiki like an editor, not like a log:
+  - Merge duplicate lessons instead of appending near-identical bullets.
+  - Keep the page compact and skimmable. Prefer 8-14 high-signal bullets.
+  - Keep examples short. Use story fingerprints or headline snippets only when
+    they clarify the lesson.
+  - Preserve nuance and variety. Do not turn feedback into rigid banned-word
+    rules or formulaic headline templates.
+  - Distinguish "rewrite" lessons from "dismiss" lessons: rewrite means the
+    story had substance but execution failed; dismiss means the source material
+    did not support a worthwhile article.
+  - The wiki is coaching, not source material. Never add football facts that
+    were not present in new_feedback_event or existing_markdown.
+
+  Output field instructions:
+  - updated_markdown: the complete replacement markdown for the target page.
+    Start with `# Rewrite And Dismissal Lessons`. Keep it under 1200 words.
+  - change_summary: one sentence describing what changed.

--- a/app/writer/prompts.yml
+++ b/app/writer/prompts.yml
@@ -149,6 +149,10 @@ article_writer_agent: |
   - Follow the rewrite_brief exactly where it is supported by source_digests.
   - Keep the same story_fingerprint, language, team discipline, and author rules.
   - Do not mention the quality gate, review process, or that this is a rewrite.
+  - Precedence: if both `existing_article` and `quality_gate_feedback` are
+    present (a rewrite of a "patch" action), `quality_gate_feedback` wins. Do
+    not preserve weak phrasing from `existing_article` just because it was
+    published before — the rewrite_brief is authoritative.
 
 article_writer_agent_de: |
   Du bist NFL-Artikelautor für T4L (Tackle4Loss) und schreibst für deutschsprachige

--- a/app/writer/workflow.py
+++ b/app/writer/workflow.py
@@ -12,9 +12,29 @@ from agents import Agent, Runner
 from app.config import Settings
 from app.editorial.helpers import coerce_output
 from app.editorial.tracing import build_run_config
-from app.schemas import ArticleSource, CyclePublishPlan, PublishableArticle, StoryEntry
+from app.schemas import (
+    ArticleQualityDecision,
+    ArticleSource,
+    CyclePublishPlan,
+    EditorialMemoryRevision,
+    PublishableArticle,
+    StoryEntry,
+)
 from app.team_codes import normalize_team_codes
-from app.writer.agents import build_article_writer_agent, build_article_writer_agent_de
+from app.writer.agents import (
+    build_article_quality_gate_agent,
+    build_article_writer_agent,
+    build_article_writer_agent_de,
+    build_editorial_memory_agent,
+)
+from app.writer.editorial_memory import (
+    append_raw_feedback,
+    build_feedback_event_markdown,
+    build_memory_revision_payload,
+    load_editorial_memory,
+    read_rewrite_lessons,
+    write_rewrite_lessons,
+)
 from app.writer.image_selector import HeadshotBudget, ImageSelector
 from app.writer.persona_selector import build_persona_selector_agent, select_persona
 from app.writer.personas import Persona, byline_to_persona_id, get_persona
@@ -56,9 +76,13 @@ class WriterWorkflow:
         os.environ.setdefault("OPENAI_API_KEY", settings.openai_api_key.get_secret_value())
         self._writer_agent_en = build_article_writer_agent(settings)
         self._writer_agent_de = build_article_writer_agent_de(settings)
+        self._quality_gate_agent = build_article_quality_gate_agent(settings)
+        self._editorial_memory_agent = build_editorial_memory_agent(settings)
         self._persona_selector_agent = build_persona_selector_agent(settings)
         self._article_writer = article_writer_adapter
         self._image_selector = image_selector
+        self._editorial_memory_dir = settings.editorial_memory_dir
+        self._editorial_memory_lock = asyncio.Lock()
 
     async def _write_in_language(
         self,
@@ -69,6 +93,8 @@ class WriterWorkflow:
         persona: Persona,
         language: str,
         existing_content: dict | None,
+        quality_gate_feedback: ArticleQualityDecision | None = None,
+        previous_draft: PublishableArticle | None = None,
     ) -> PublishableArticle:
         """Pure writer call for one language — NO image cascade here.
 
@@ -86,8 +112,19 @@ class WriterWorkflow:
             "player_mentions": [pm.model_dump(mode="json") for pm in story.player_mentions],
             "persona": dataclasses.asdict(persona),
         }
+        if language == "en-US":
+            memory = load_editorial_memory(self._editorial_memory_dir, story)
+            if memory:
+                writer_payload["editorial_memory"] = memory
         if existing_content is not None:
             writer_payload["existing_article"] = existing_content
+        if quality_gate_feedback is not None:
+            writer_payload["quality_gate_feedback"] = quality_gate_feedback.model_dump(
+                mode="json"
+            )
+            writer_payload["previous_draft"] = (
+                previous_draft.model_dump(mode="json") if previous_draft else None
+            )
 
         writer_input = json.dumps(writer_payload, separators=(",", ":"))
 
@@ -119,6 +156,202 @@ class WriterWorkflow:
         if article.sources != deterministic_sources:
             overrides["sources"] = deterministic_sources
         return article.model_copy(update=overrides)
+
+    async def _run_quality_gate(
+        self,
+        story: StoryEntry,
+        article: PublishableArticle,
+        cycle_id: str,
+        *,
+        persona: Persona,
+        rewrite_attempt: int,
+    ) -> ArticleQualityDecision:
+        payload = {
+            "story": {
+                "cluster_headline": story.cluster_headline,
+                "story_fingerprint": story.story_fingerprint,
+                "action": story.action,
+                "news_value_score": story.news_value_score,
+                "team_codes": normalize_team_codes(story.team_codes),
+                "player_mentions": [
+                    pm.model_dump(mode="json") for pm in story.player_mentions
+                ],
+            },
+            "source_digests": [d.model_dump(mode="json") for d in story.source_digests],
+            "article": article.model_dump(mode="json"),
+            "persona": dataclasses.asdict(persona),
+            "rewrite_attempt": rewrite_attempt,
+        }
+        run_config = build_run_config(
+            cycle_id,
+            stage="article_quality_gate",
+            metadata={
+                "fingerprint": story.story_fingerprint,
+                "language": article.language,
+                "rewrite_attempt": rewrite_attempt,
+            },
+        )
+        try:
+            result = await Runner.run(
+                self._quality_gate_agent,
+                json.dumps(payload, separators=(",", ":")),
+                run_config=run_config,
+                max_turns=3,
+                auto_previous_response_id=True,
+            )
+            decision = coerce_output(result.final_output, ArticleQualityDecision)
+            logger.info(
+                "Quality gate %s for %s: impact=%.2f specificity=%.2f read=%.2f "
+                "grounding=%.2f execution=%.2f — %s",
+                decision.decision,
+                article.headline[:60],
+                decision.impact_score,
+                decision.specificity_score,
+                decision.readworthiness_score,
+                decision.grounding_score,
+                decision.execution_score,
+                decision.reasoning,
+            )
+            return decision
+        except Exception as exc:
+            logger.warning(
+                "Quality gate failed for %s — dismissing story for this cycle: %s",
+                article.headline[:60],
+                exc,
+            )
+            return ArticleQualityDecision(
+                decision="dismiss",
+                impact_score=0.0,
+                specificity_score=0.0,
+                readworthiness_score=0.0,
+                grounding_score=0.0,
+                execution_score=0.0,
+                reasoning="Quality gate unavailable; story dismissed by fail-closed policy.",
+                rewrite_brief=None,
+            )
+
+    async def _record_editorial_feedback(
+        self,
+        *,
+        cycle_id: str,
+        story: StoryEntry,
+        article: PublishableArticle,
+        persona: Persona,
+        decision: ArticleQualityDecision,
+        rewrite_attempt: int,
+    ) -> None:
+        if decision.decision == "approve" and rewrite_attempt == 0:
+            return
+
+        event_markdown = build_feedback_event_markdown(
+            cycle_id=cycle_id,
+            story=story,
+            article=article,
+            persona=persona,
+            decision=decision,
+            rewrite_attempt=rewrite_attempt,
+        )
+        async with self._editorial_memory_lock:
+            try:
+                append_raw_feedback(self._editorial_memory_dir, event_markdown)
+                existing_markdown = read_rewrite_lessons(self._editorial_memory_dir)
+                payload = build_memory_revision_payload(
+                    existing_markdown=existing_markdown,
+                    feedback_event_markdown=event_markdown,
+                )
+                run_config = build_run_config(
+                    cycle_id,
+                    stage="editorial_memory_update",
+                    metadata={
+                        "fingerprint": story.story_fingerprint,
+                        "decision": decision.decision,
+                        "rewrite_attempt": rewrite_attempt,
+                    },
+                )
+                result = await Runner.run(
+                    self._editorial_memory_agent,
+                    json.dumps(payload, separators=(",", ":")),
+                    run_config=run_config,
+                    max_turns=3,
+                    auto_previous_response_id=True,
+                )
+                revision = coerce_output(result.final_output, EditorialMemoryRevision)
+                write_rewrite_lessons(
+                    self._editorial_memory_dir,
+                    revision.updated_markdown,
+                )
+                logger.info(
+                    "Updated editorial memory for %s: %s",
+                    story.story_fingerprint,
+                    revision.change_summary,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Editorial memory update failed for %s: %s",
+                    story.story_fingerprint,
+                    exc,
+                )
+
+    async def _approve_or_rewrite_en_article(
+        self,
+        story: StoryEntry,
+        cycle_id: str,
+        *,
+        persona: Persona,
+        article: PublishableArticle,
+        existing_content: dict | None,
+    ) -> PublishableArticle | None:
+        decision = await self._run_quality_gate(
+            story, article, cycle_id, persona=persona, rewrite_attempt=0
+        )
+        await self._record_editorial_feedback(
+            cycle_id=cycle_id,
+            story=story,
+            article=article,
+            persona=persona,
+            decision=decision,
+            rewrite_attempt=0,
+        )
+        if decision.decision == "approve":
+            return article
+        if decision.decision == "dismiss":
+            logger.info(
+                "Quality gate dismissed story before DE/image: %s — %s",
+                story.cluster_headline[:60],
+                decision.reasoning,
+            )
+            return None
+
+        rewritten = await self._write_in_language(
+            story,
+            cycle_id,
+            agent=self._writer_agent_en,
+            persona=persona,
+            language="en-US",
+            existing_content=existing_content,
+            quality_gate_feedback=decision,
+            previous_draft=article,
+        )
+        second_decision = await self._run_quality_gate(
+            story, rewritten, cycle_id, persona=persona, rewrite_attempt=1
+        )
+        await self._record_editorial_feedback(
+            cycle_id=cycle_id,
+            story=story,
+            article=rewritten,
+            persona=persona,
+            decision=second_decision,
+            rewrite_attempt=1,
+        )
+        if second_decision.decision == "approve":
+            return rewritten
+
+        logger.info(
+            "Quality gate rejected story after rewrite (%s): %s",
+            second_decision.decision,
+            second_decision.reasoning,
+        )
+        return None
 
     async def _select_image_for_story(
         self,
@@ -187,6 +420,15 @@ class WriterWorkflow:
             language="en-US",
             existing_content=existing_en_content,
         )
+        en_article = await self._approve_or_rewrite_en_article(
+            story,
+            cycle_id,
+            persona=persona_en,
+            article=en_article,
+            existing_content=existing_en_content,
+        )
+        if en_article is None:
+            return []
 
         # 2. Image cascade (once per story)
         image_url = await self._select_image_for_story(

--- a/app/writer/workflow.py
+++ b/app/writer/workflow.py
@@ -214,11 +214,29 @@ class WriterWorkflow:
             )
             return decision
         except Exception as exc:
-            logger.warning(
-                "Quality gate failed for %s — dismissing story for this cycle: %s",
+            fallback = "approve original draft" if rewrite_attempt == 0 else "dismiss rewrite"
+            logger.error(
+                "QUALITY_GATE_OUTAGE: gate unavailable for %s "
+                "(rewrite_attempt=%d) — falling back to %s: %s",
                 article.headline[:60],
+                rewrite_attempt,
+                fallback,
                 exc,
             )
+            if rewrite_attempt == 0:
+                return ArticleQualityDecision(
+                    decision="approve",
+                    impact_score=0.5,
+                    specificity_score=0.5,
+                    readworthiness_score=0.5,
+                    grounding_score=0.5,
+                    execution_score=0.5,
+                    reasoning=(
+                        "Quality gate unavailable; approving original draft by "
+                        "fail-soft policy (writer-prompt discipline applies)."
+                    ),
+                    rewrite_brief=None,
+                )
             return ArticleQualityDecision(
                 decision="dismiss",
                 impact_score=0.0,
@@ -226,7 +244,10 @@ class WriterWorkflow:
                 readworthiness_score=0.0,
                 grounding_score=0.0,
                 execution_score=0.0,
-                reasoning="Quality gate unavailable; story dismissed by fail-closed policy.",
+                reasoning=(
+                    "Quality gate unavailable on rewrite attempt; dismissing to "
+                    "avoid publishing an unreviewed second draft."
+                ),
                 rewrite_brief=None,
             )
 

--- a/editorial_memory/wiki/headline_patterns_that_work.md
+++ b/editorial_memory/wiki/headline_patterns_that_work.md
@@ -1,0 +1,16 @@
+# Headline Patterns That Work
+
+Use these as flexible examples, not templates.
+
+- Name plus consequence: "Chiefs face tougher Rashee Rice decision as timeline
+  drags"
+- Team plus concrete status: "Bills lose starting safety for Week 7 after IR
+  move"
+- Quote/rank/grade plus payoff: "Ravens' draft grade turns on second-round
+  value pick"
+- Decision-point headline: "Cowboys must weigh cap hit before next Prescott
+  move"
+- Avoid broad labels unless the exact fact sits next to them. "Update" is weak;
+  "injury update puts Week 4 status in doubt" is useful.
+- A strong headline can be quiet. It does not need hype if the fact and payoff
+  are clear.

--- a/editorial_memory/wiki/rewrite_lessons.md
+++ b/editorial_memory/wiki/rewrite_lessons.md
@@ -1,0 +1,3 @@
+# Rewrite And Dismissal Lessons
+
+- No runtime quality-gate lessons have been compiled yet.

--- a/editorial_memory/wiki/thin_story_rejection_rules.md
+++ b/editorial_memory/wiki/thin_story_rejection_rules.md
@@ -1,0 +1,16 @@
+# Thin Story Rejection Rules
+
+These notes help the writer recognize stories that should not be rescued with
+padding.
+
+- Dismiss source material when the only fact is that a team appeared in a
+  roundup, watch list, offseason storyline list, or national conversation.
+- Dismiss when there is no named player, coach, executive, opponent, transaction,
+  timeline, quote, number, rank, grade, injury/status label, or team-specific
+  consequence.
+- Rewrite instead of dismiss when the source has a concrete fact but the draft
+  buries it under generic setup.
+- Do not turn absence of detail into a story. If the source says nothing
+  specific, a shorter article is not enough; the story may not deserve publishing.
+- Thin does not mean unimportant. A thin source with one hard fact can still pass
+  if that fact changes a team's immediate plan.

--- a/editorial_memory/wiki/what_makes_a_story_readworthy.md
+++ b/editorial_memory/wiki/what_makes_a_story_readworthy.md
@@ -1,0 +1,18 @@
+# What Makes A Story Readworthy
+
+Use these notes as editorial coaching for T4L news drafts. They are not source
+facts.
+
+- A good T4L story gives a fan a concrete reason to tap now: a named person,
+  team decision, roster consequence, injury/status change, quote, rank, grade,
+  number, or deadline.
+- Small stories can work when they are specific. A backup signing, practice
+  status, or depth-chart note is publishable if the article explains the direct
+  team consequence.
+- Broad attention is not a story by itself. "The Chiefs are drawing offseason
+  attention" needs a named player, move, quote, number, or decision point before
+  it deserves a full article.
+- The first screen should answer: what changed, who is central, and why it
+  matters now.
+- The safest way to add color is to sharpen the consequence, not inflate the
+  drama. If the source only supports uncertainty, make the uncertainty concrete.

--- a/tests/test_article_quality_gate.py
+++ b/tests/test_article_quality_gate.py
@@ -170,7 +170,7 @@ async def test_quality_gate_rewrite_failure_dismisses_after_one_retry():
     assert result is None
 
 
-async def test_quality_gate_failure_fails_closed(monkeypatch):
+async def test_quality_gate_failure_on_first_attempt_fails_soft(monkeypatch):
     workflow = WriterWorkflow.__new__(WriterWorkflow)
     workflow._quality_gate_agent = object()
 
@@ -187,5 +187,26 @@ async def test_quality_gate_failure_fails_closed(monkeypatch):
         rewrite_attempt=0,
     )
 
+    assert decision.decision == "approve"
+    assert "fail-soft" in decision.reasoning
+
+
+async def test_quality_gate_failure_on_rewrite_dismisses(monkeypatch):
+    workflow = WriterWorkflow.__new__(WriterWorkflow)
+    workflow._quality_gate_agent = object()
+
+    async def fail(*args, **kwargs):
+        raise RuntimeError("gate unavailable")
+
+    monkeypatch.setattr(workflow_module.Runner, "run", fail)
+
+    decision = await workflow._run_quality_gate(
+        _story(),
+        _article(),
+        "cycle",
+        persona=get_persona("insider"),
+        rewrite_attempt=1,
+    )
+
     assert decision.decision == "dismiss"
-    assert "fail-closed" in decision.reasoning
+    assert "rewrite attempt" in decision.reasoning

--- a/tests/test_article_quality_gate.py
+++ b/tests/test_article_quality_gate.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from app.schemas import ArticleDigest, ArticleQualityDecision, PublishableArticle, StoryEntry
+from app.writer.personas import get_persona
+import app.writer.workflow as workflow_module
+from app.writer.workflow import WriterWorkflow
+
+
+def _decision(decision: str, rewrite_brief: str | None = None) -> ArticleQualityDecision:
+    return ArticleQualityDecision(
+        decision=decision,  # type: ignore[arg-type]
+        impact_score=0.8,
+        specificity_score=0.8,
+        readworthiness_score=0.8,
+        grounding_score=0.9,
+        execution_score=0.8,
+        reasoning=f"{decision} reasoning",
+        rewrite_brief=rewrite_brief,
+    )
+
+
+def _story() -> StoryEntry:
+    return StoryEntry(
+        rank=1,
+        cluster_headline="Chiefs face a tougher roster decision",
+        story_fingerprint="fp",
+        action="publish",
+        news_value_score=0.82,
+        reasoning="Concrete team impact",
+        source_digests=[
+            ArticleDigest(
+                story_id="s1",
+                url="https://example.com/story",
+                title="Chiefs roster decision sharpens",
+                source_name="Example",
+                summary="The Chiefs have a roster decision after a named update.",
+                key_facts=["Kansas City must make a roster decision by Tuesday"],
+                confidence=0.9,
+                content_status="full",
+                team_mentions=["KC"],
+            )
+        ],
+        team_codes=["KC"],
+    )
+
+
+def _article(headline: str = "Chiefs face roster decision") -> PublishableArticle:
+    return PublishableArticle(
+        team="KC",
+        headline=headline,
+        sub_headline="Kansas City has a concrete decision on its calendar",
+        introduction="Kansas City has a decision to make by Tuesday.",
+        content="Kansas City has a decision to make by Tuesday.\n\nThe timing matters.",
+        x_post="Kansas City has a concrete roster decision due by Tuesday.",
+        bullet_points="- Kansas City has a decision due Tuesday",
+        story_fingerprint="fp",
+        author="Jenna Alvarez",
+    )
+
+
+async def no_op_record(*args, **kwargs):
+    return None
+
+
+async def test_quality_gate_approve_returns_original_article():
+    workflow = WriterWorkflow.__new__(WriterWorkflow)
+    calls: list[int] = []
+
+    async def gate(*args, rewrite_attempt: int, **kwargs):
+        calls.append(rewrite_attempt)
+        return _decision("approve")
+
+    workflow._run_quality_gate = gate  # type: ignore[method-assign]
+    workflow._record_editorial_feedback = no_op_record  # type: ignore[method-assign]
+    result = await workflow._approve_or_rewrite_en_article(
+        _story(),
+        "cycle",
+        persona=get_persona("insider"),
+        article=_article(),
+        existing_content=None,
+    )
+
+    assert result is not None
+    assert result.headline == "Chiefs face roster decision"
+    assert calls == [0]
+
+
+async def test_quality_gate_dismiss_stops_story_before_rewrite():
+    workflow = WriterWorkflow.__new__(WriterWorkflow)
+
+    async def gate(*args, rewrite_attempt: int, **kwargs):
+        return _decision("dismiss")
+
+    async def write(*args, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError("dismissed story should not be rewritten")
+
+    workflow._run_quality_gate = gate  # type: ignore[method-assign]
+    workflow._write_in_language = write  # type: ignore[method-assign]
+    workflow._record_editorial_feedback = no_op_record  # type: ignore[method-assign]
+
+    result = await workflow._approve_or_rewrite_en_article(
+        _story(),
+        "cycle",
+        persona=get_persona("insider"),
+        article=_article(),
+        existing_content=None,
+    )
+
+    assert result is None
+
+
+async def test_quality_gate_rewrite_gets_one_retry_then_approves():
+    workflow = WriterWorkflow.__new__(WriterWorkflow)
+    calls: list[int] = []
+
+    async def gate(*args, rewrite_attempt: int, **kwargs):
+        calls.append(rewrite_attempt)
+        if rewrite_attempt == 0:
+            return _decision("rewrite", rewrite_brief="Lead with the Tuesday deadline.")
+        return _decision("approve")
+
+    async def write(*args, quality_gate_feedback, previous_draft, **kwargs):
+        assert quality_gate_feedback.rewrite_brief == "Lead with the Tuesday deadline."
+        assert previous_draft.headline == "Chiefs face roster decision"
+        return _article("Chiefs roster deadline sharpens Tuesday decision")
+
+    workflow._run_quality_gate = gate  # type: ignore[method-assign]
+    workflow._write_in_language = write  # type: ignore[method-assign]
+    workflow._record_editorial_feedback = no_op_record  # type: ignore[method-assign]
+    workflow._writer_agent_en = object()
+
+    result = await workflow._approve_or_rewrite_en_article(
+        _story(),
+        "cycle",
+        persona=get_persona("insider"),
+        article=_article(),
+        existing_content=None,
+    )
+
+    assert result is not None
+    assert result.headline == "Chiefs roster deadline sharpens Tuesday decision"
+    assert calls == [0, 1]
+
+
+async def test_quality_gate_rewrite_failure_dismisses_after_one_retry():
+    workflow = WriterWorkflow.__new__(WriterWorkflow)
+
+    async def gate(*args, rewrite_attempt: int, **kwargs):
+        return _decision(
+            "rewrite",
+            rewrite_brief="Still needs a sharper source-supported consequence.",
+        )
+
+    async def write(*args, **kwargs):
+        return _article("Chiefs still need sharper angle")
+
+    workflow._run_quality_gate = gate  # type: ignore[method-assign]
+    workflow._write_in_language = write  # type: ignore[method-assign]
+    workflow._record_editorial_feedback = no_op_record  # type: ignore[method-assign]
+    workflow._writer_agent_en = object()
+
+    result = await workflow._approve_or_rewrite_en_article(
+        _story(),
+        "cycle",
+        persona=get_persona("insider"),
+        article=_article(),
+        existing_content=None,
+    )
+
+    assert result is None
+
+
+async def test_quality_gate_failure_fails_closed(monkeypatch):
+    workflow = WriterWorkflow.__new__(WriterWorkflow)
+    workflow._quality_gate_agent = object()
+
+    async def fail(*args, **kwargs):
+        raise RuntimeError("gate unavailable")
+
+    monkeypatch.setattr(workflow_module.Runner, "run", fail)
+
+    decision = await workflow._run_quality_gate(
+        _story(),
+        _article(),
+        "cycle",
+        persona=get_persona("insider"),
+        rewrite_attempt=0,
+    )
+
+    assert decision.decision == "dismiss"
+    assert "fail-closed" in decision.reasoning

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,9 @@ def fake_settings(monkeypatch: pytest.MonkeyPatch) -> Settings:
         "OPENAI_MODEL_STORY_CLUSTER_AGENT",
         "OPENAI_MODEL_EDITORIAL_ORCHESTRATOR_AGENT",
         "OPENAI_MODEL_ARTICLE_WRITER_AGENT",
+        "OPENAI_MODEL_ARTICLE_QUALITY_GATE_AGENT",
+        "OPENAI_MODEL_PERSONA_SELECTOR_AGENT",
+        "OPENAI_MODEL_EDITORIAL_MEMORY_AGENT",
     ):
         monkeypatch.delenv(key, raising=False)
     return Settings(_env_file=None)
@@ -45,4 +48,6 @@ class TestSettings:
             "editorial_orchestrator_agent",
             "article_writer_agent",
             "persona_selector_agent",
+            "article_quality_gate_agent",
+            "editorial_memory_agent",
         }

--- a/tests/test_editorial_memory.py
+++ b/tests/test_editorial_memory.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from app.schemas import ArticleDigest, ArticleQualityDecision, EditorialMemoryRevision, StoryEntry
+from app.writer.editorial_memory import (
+    append_raw_feedback,
+    build_feedback_event_markdown,
+    load_editorial_memory,
+    read_rewrite_lessons,
+)
+from app.writer.personas import get_persona
+import app.writer.workflow as workflow_module
+from app.writer.workflow import WriterWorkflow
+
+from tests.test_article_quality_gate import _article
+
+
+def _story() -> StoryEntry:
+    return StoryEntry(
+        rank=1,
+        cluster_headline="Chiefs face a sharper receiver decision",
+        story_fingerprint="fp-memory",
+        action="publish",
+        news_value_score=0.8,
+        reasoning="Useful team consequence",
+        source_digests=[
+            ArticleDigest(
+                story_id="s1",
+                url="https://example.com/story",
+                title="Chiefs receiver decision sharpens",
+                source_name="Example",
+                summary="Kansas City has a concrete receiver decision.",
+                key_facts=["Kansas City must make a receiver decision by Tuesday"],
+                confidence=0.9,
+                content_status="full",
+                team_mentions=["KC"],
+            )
+        ],
+        team_codes=["KC"],
+    )
+
+
+def _decision(decision: str = "rewrite") -> ArticleQualityDecision:
+    return ArticleQualityDecision(
+        decision=decision,  # type: ignore[arg-type]
+        impact_score=0.7,
+        specificity_score=0.6,
+        readworthiness_score=0.5,
+        grounding_score=0.9,
+        execution_score=0.4,
+        reasoning="The draft buried the concrete deadline.",
+        rewrite_brief="Lead with the Tuesday receiver deadline.",
+    )
+
+
+def test_load_editorial_memory_reads_wiki_pages(tmp_path):
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    (wiki / "what_makes_a_story_readworthy.md").write_text(
+        "# What Makes A Story Readworthy\n\n- Lead with concrete consequence.",
+        encoding="utf-8",
+    )
+    (wiki / "rewrite_lessons.md").write_text(
+        "# Rewrite And Dismissal Lessons\n\n- Do not bury deadlines.",
+        encoding="utf-8",
+    )
+
+    memory = load_editorial_memory(tmp_path, _story())
+
+    assert "Treat as coaching, not facts" in memory
+    assert "Lead with concrete consequence" in memory
+    assert "Do not bury deadlines" in memory
+    assert "Chiefs face a sharper receiver decision" in memory
+
+
+def test_append_raw_feedback_writes_daily_markdown(tmp_path):
+    event = build_feedback_event_markdown(
+        cycle_id="cycle",
+        story=_story(),
+        article=_article(),
+        persona=get_persona("insider"),
+        decision=_decision(),
+        rewrite_attempt=0,
+    )
+
+    path = append_raw_feedback(tmp_path, event)
+
+    text = path.read_text(encoding="utf-8")
+    assert "# Editorial Feedback Events" in text
+    assert "Lead with the Tuesday receiver deadline" in text
+
+
+async def test_write_in_language_injects_editorial_memory(tmp_path, monkeypatch):
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    (wiki / "what_makes_a_story_readworthy.md").write_text(
+        "# What Makes A Story Readworthy\n\n- Lead with concrete consequence.",
+        encoding="utf-8",
+    )
+
+    workflow = WriterWorkflow.__new__(WriterWorkflow)
+    workflow._editorial_memory_dir = tmp_path
+    seen_payload: dict | None = None
+
+    async def fake_run(agent, writer_input, **kwargs):
+        nonlocal seen_payload
+        seen_payload = json.loads(writer_input)
+        return SimpleNamespace(final_output=_article())
+
+    monkeypatch.setattr(workflow_module.Runner, "run", fake_run)
+
+    await workflow._write_in_language(
+        _story(),
+        "cycle",
+        agent=object(),
+        persona=get_persona("insider"),
+        language="en-US",
+        existing_content=None,
+    )
+
+    assert seen_payload is not None
+    assert "editorial_memory" in seen_payload
+    assert "Lead with concrete consequence" in seen_payload["editorial_memory"]
+
+
+async def test_record_editorial_feedback_updates_rewrite_lessons(tmp_path, monkeypatch):
+    workflow = WriterWorkflow.__new__(WriterWorkflow)
+    workflow._editorial_memory_dir = tmp_path
+    workflow._editorial_memory_lock = asyncio.Lock()
+    workflow._editorial_memory_agent = object()
+
+    async def fake_run(agent, payload, **kwargs):
+        return SimpleNamespace(
+            final_output=EditorialMemoryRevision(
+                updated_markdown=(
+                    "# Rewrite And Dismissal Lessons\n\n"
+                    "- Lead with the concrete deadline when it exists."
+                ),
+                change_summary="Added deadline lesson.",
+            )
+        )
+
+    monkeypatch.setattr(workflow_module.Runner, "run", fake_run)
+
+    await workflow._record_editorial_feedback(
+        cycle_id="cycle",
+        story=_story(),
+        article=_article(),
+        persona=get_persona("insider"),
+        decision=_decision(),
+        rewrite_attempt=0,
+    )
+
+    assert "concrete deadline" in read_rewrite_lessons(tmp_path)
+    raw_files = list((tmp_path / "raw_feedback").glob("*.md"))
+    assert len(raw_files) == 1

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -7,8 +7,10 @@ from pydantic import ValidationError
 from app.schemas import (
     ArticleDigest,
     ArticleDigestAgentResult,
+    ArticleQualityDecision,
     CyclePublishPlan,
     CycleResult,
+    EditorialMemoryRevision,
     EntityMatch,
     PublishableArticle,
     PublishedStoryRecord,
@@ -106,6 +108,43 @@ class TestPublishableArticle:
                 team="BUF", headline="h", sub_headline="s", introduction="i",
                 content="c", x_post="x", bullet_points="b", story_fingerprint="fp",
                 bogus="bad",
+            )
+
+
+class TestArticleQualityDecision:
+    def test_forbids_extra(self) -> None:
+        with pytest.raises(ValidationError, match="extra"):
+            ArticleQualityDecision(
+                decision="approve",
+                impact_score=0.8,
+                specificity_score=0.8,
+                readworthiness_score=0.8,
+                grounding_score=0.9,
+                execution_score=0.8,
+                reasoning="Strong enough",
+                extra="bad",
+            )
+
+    def test_score_bounds(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleQualityDecision(
+                decision="approve",
+                impact_score=1.1,
+                specificity_score=0.8,
+                readworthiness_score=0.8,
+                grounding_score=0.9,
+                execution_score=0.8,
+                reasoning="Strong enough",
+            )
+
+
+class TestEditorialMemoryRevision:
+    def test_forbids_extra(self) -> None:
+        with pytest.raises(ValidationError, match="extra"):
+            EditorialMemoryRevision(
+                updated_markdown="# Lessons",
+                change_summary="Updated lessons",
+                extra="bad",
             )
 
 


### PR DESCRIPTION
## Summary
- tighten editorial and writer prompts around reader payoff, specificity, and concrete angles
- add an LLM-only article quality gate with approve/rewrite/dismiss decisions before image and DE generation
- add repo-local markdown editorial memory that feeds EN drafting and learns from quality-gate feedback
- persist editorial memory updates from the scheduled GitHub Action

## Tests
- ./venv/bin/pytest