### PR TITLE
chore: day closing 2026-05-01

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,12 @@ Includes score calibration anchors and explicit hard-fail triggers so borderline
 
 Wiki schema captures both "what works" and "what to avoid" sections. `writer/workflow.py` feeds 1-in-5 clean approves (deterministic by fingerprint hash) alongside rejections so the memory accumulates positive lessons.
 
+Memory injection is controlled by two caps in `app/writer/editorial_memory.py`:
+- `MAX_WIKI_PAGE_CHARS = 7000` — maximum chars read from any single wiki page before truncation (raised from 2400 on 2026-05-01 after `rewrite_lessons.md` grew past the old cap and was silently cut).
+- `MAX_MEMORY_CHARS = 12000` — maximum total chars injected across all wiki pages combined.
+
+A wiki-summary-agent (smarter alternative) was deferred; a remote agent fires 2026-05-15 to evaluate whether to build it.
+
 ### article_data_agent
 
 Includes a "Roundup / ranking / grade extraction rule": for multi-team source pieces it must extract row-level verdicts as `key_facts`, not column-level meta. If only column-level meta is available, `content_status="thin"` + `confidence <= 0.3` is required, routing downstream to the writer's "thin → write shorter" path. Interlocks with the writer prompts.

--- a/app/writer/editorial_memory.py
+++ b/app/writer/editorial_memory.py
@@ -9,8 +9,8 @@ from app.writer.personas import Persona
 WIKI_DIRNAME = "wiki"
 RAW_FEEDBACK_DIRNAME = "raw_feedback"
 REWRITE_LESSONS_FILE = "rewrite_lessons.md"
-MAX_MEMORY_CHARS = 7000
-MAX_WIKI_PAGE_CHARS = 2400
+MAX_MEMORY_CHARS = 12000
+MAX_WIKI_PAGE_CHARS = 7000
 
 
 def _read_markdown(path: Path, *, max_chars: int = MAX_WIKI_PAGE_CHARS) -> str:

--- a/app/writer/workflow.py
+++ b/app/writer/workflow.py
@@ -189,7 +189,7 @@ class WriterWorkflow:
             metadata={
                 "fingerprint": story.story_fingerprint,
                 "language": article.language,
-                "rewrite_attempt": rewrite_attempt,
+                "rewrite_attempt": str(rewrite_attempt),
             },
         )
         try:
@@ -292,7 +292,7 @@ class WriterWorkflow:
                     metadata={
                         "fingerprint": story.story_fingerprint,
                         "decision": decision.decision,
-                        "rewrite_attempt": rewrite_attempt,
+                        "rewrite_attempt": str(rewrite_attempt),
                     },
                 )
                 result = await Runner.run(


### PR DESCRIPTION
## Summary
- Fixed non-fatal OpenAI traces 400 error: `rewrite_attempt` metadata value cast from `int` to `str` in two `build_run_config` call sites in `writer/workflow.py`
- Raised editorial memory caps (`MAX_WIKI_PAGE_CHARS` 2400→7000, `MAX_MEMORY_CHARS` 7000→12000) to prevent silent truncation of `rewrite_lessons.md` before it reaches the article writer agent
- Updated CLAUDE.md to document the cap constants and the deferred wiki-summary-agent decision

## Changes
- `app/writer/workflow.py` — `str(rewrite_attempt)` in `article_quality_gate` and `editorial_memory_update` metadata dicts
- `app/writer/editorial_memory.py` — cap constants raised
- `CLAUDE.md` — editorial_memory_agent section updated with cap values and rationale

## Test plan
- [x] Tests run: 191 passed, 0 failed
- [x] Linting run: SKIPPED (no linter configured; no UI files changed)
- [x] Documentation files updated: CLAUDE.md (editorial_memory_agent section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)